### PR TITLE
Gate service startup on ArangoDB readiness, not just container start

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -25,8 +25,10 @@ services:
     ports:
       - 127.0.0.1:8000:8000
     depends_on:
-      - redis
-      - arangodb
+      redis:
+        condition: service_started
+      arangodb:
+        condition: service_healthy
     volumes:
       - /tmp/docker-yeti-exports:/opt/yeti/exports
       - ./yeti/:/app/
@@ -61,6 +63,12 @@ services:
       - 127.0.0.1:8529:8529
     environment:
       - ARANGO_ROOT_PASSWORD=
+    healthcheck:
+      test: ["CMD-SHELL", "arangosh --server.endpoint tcp://127.0.0.1:8529 --server.username root --server.password \"$$ARANGO_ROOT_PASSWORD\" --javascript.execute-string 'db._version()' >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 10
 
   # Microservices
 

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -19,8 +19,10 @@ services:
     ports:
       - 8001:8000
     depends_on:
-      - redis
-      - arangodb
+      redis:
+        condition: service_started
+      arangodb:
+        condition: service_healthy
     volumes:
       - yeti-exports:/opt/yeti/exports
 
@@ -30,9 +32,12 @@ services:
       - ${YETI_DOCKER_ENVFILE}
     command: ['tasks']
     depends_on:
-      - redis
-      - arangodb
-      - api
+      redis:
+        condition: service_started
+      arangodb:
+        condition: service_healthy
+      api:
+        condition: service_started
     volumes:
       - yeti-exports:/opt/yeti/exports
 
@@ -42,9 +47,12 @@ services:
       - ${YETI_DOCKER_ENVFILE}
     command: ['events-tasks']
     depends_on:
-      - redis
-      - arangodb
-      - api
+      redis:
+        condition: service_started
+      arangodb:
+        condition: service_healthy
+      api:
+        condition: service_started
     volumes:
       - yeti-exports:/opt/yeti/exports
 
@@ -54,7 +62,10 @@ services:
       - ${YETI_DOCKER_ENVFILE}
     command: ['tasks-beat']
     depends_on:
-      - redis
+      redis:
+        condition: service_started
+      arangodb:
+        condition: service_healthy
 
   redis:
     image: redis:latest
@@ -66,6 +77,12 @@ services:
       - ARANGO_ROOT_PASSWORD=
     volumes:
       - yeti-db:/var/lib/arangodb3
+    healthcheck:
+      test: ["CMD-SHELL", "arangosh --server.endpoint tcp://127.0.0.1:8529 --server.username root --server.password \"$$ARANGO_ROOT_PASSWORD\" --javascript.execute-string 'db._version()' >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 10
 
   bloomcheck:
     image: yetiplatform/bloomcheck:${YETI_IMAGE_TAG:-latest}


### PR DESCRIPTION
## Summary

Closes the root cause behind #29 ("Feed tasks are not initialized on fresh installation").

`depends_on: [arangodb]` (the short list form) only waits for the `arangodb`
container *process* to start, not for the ArangoDB server inside it to
actually accept connections. On a genuinely fresh install (empty
`yeti-db` volume), ArangoDB's very first boot takes noticeably longer to
initialize than a warm restart — and the `api`/`tasks`/`events-tasks`/
`tasks-beat` containers were starting their plugin-import phase during
that window.

That plugin-import phase is what registers every feed as a `Task` document
in ArangoDB, as a side effect of importing each plugin module
(`core/taskscheduler.py`'s `get_plugins_list()` → `core/taskmanager.py`'s
`register_task()`). If ArangoDB isn't reachable yet, those one-shot
registration writes fail — and the backend's plugin loader silently drops
the failure (logs a warning and moves on to the next plugin), so the
`tasks` collection stays empty for that container's entire lifetime, even
though the app otherwise starts fine and serves requests correctly once
ArangoDB does come up a few seconds later. This matches the reported
symptom exactly: app starts, auth works, Feeds page is permanently empty,
`{"tasks":[],"total":0}`.

(Running `yetictl list-tasks` manually afterwards "fixes" the visible
symptom because it's a fresh process that re-imports every plugin — by
then ArangoDB is definitely up — but that doesn't help the *already
running* webserver/celery-worker processes, since each only gets one shot
at registration, at import time.)

## Fix

- Add a `healthcheck` to the `arangodb` service (both `dev/` and `prod/`
  compose files) that authenticates via `arangosh` using the same root
  credentials the app itself uses (`ARANGO_ROOT_PASSWORD`), so it proves
  the server is actually answering authenticated requests, not just that
  the TCP port is open.
- Switch `api`/`tasks`/`events-tasks`/`tasks-beat` from the short
  `depends_on` list form to the long form with
  `arangodb: condition: service_healthy`, so they wait for the database to
  be ready rather than merely started.
- `tasks-beat` previously had **no** dependency on `arangodb` at all,
  despite importing the exact same plugin-registration path
  (`core.taskscheduler beat`) — added one.

This is a compose-level mitigation; a companion backend fix (making the
plugin loader fail loudly instead of silently swallowing DB-connectivity
errors during task registration) is planned separately in
`yeti-platform/yeti`.

## Test plan

- [x] `docker compose config -q` validates both `dev/docker-compose.yaml`
      and `prod/docker-compose.yaml` with no errors.
- [x] Recreated the dev `arangodb` container with the new healthcheck
      attached and confirmed it reports `"Status": "healthy"` with exit
      code 0 on every check (verified via
      `docker inspect --format='{{json .State.Health}}'`).
- [x] Confirmed the `$$ARANGO_ROOT_PASSWORD` compose-escaping resolves
      correctly at container runtime (the healthcheck's `arangosh` auth
      only succeeds if the literal env var name reaches the container's
      shell rather than being interpolated away by Compose at parse time).