### PR TITLE
Add a real-backend integration E2E suite (frontend + API + ArangoDB)

### DIFF
--- a/.github/workflows/integration-e2e.yaml
+++ b/.github/workflows/integration-e2e.yaml
@@ -18,17 +18,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out yeti-docker
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Check out yeti
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: yeti-platform/yeti
           ref: ${{ inputs.yeti_ref }}
           path: dev/yeti
 
       - name: Check out yeti-feeds-frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: yeti-platform/yeti-feeds-frontend
           ref: ${{ inputs.frontend_ref }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: integration-tests/playwright/playwright-report/

--- a/.github/workflows/integration-e2e.yaml
+++ b/.github/workflows/integration-e2e.yaml
@@ -1,0 +1,47 @@
+name: Integration E2E (real backend + frontend)
+
+on:
+  workflow_dispatch:
+    inputs:
+      yeti_ref:
+        description: "yeti-platform/yeti ref to test (branch, tag, or SHA)"
+        required: false
+        default: "main"
+      frontend_ref:
+        description: "yeti-platform/yeti-feeds-frontend ref to test"
+        required: false
+        default: "main"
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out yeti-docker
+        uses: actions/checkout@v4
+
+      - name: Check out yeti
+        uses: actions/checkout@v4
+        with:
+          repository: yeti-platform/yeti
+          ref: ${{ inputs.yeti_ref }}
+          path: dev/yeti
+
+      - name: Check out yeti-feeds-frontend
+        uses: actions/checkout@v4
+        with:
+          repository: yeti-platform/yeti-feeds-frontend
+          ref: ${{ inputs.frontend_ref }}
+          path: dev/yeti-feeds-frontend
+
+      - name: Run the integration suite
+        run: ./run.sh
+        working-directory: integration-tests
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: integration-tests/playwright/playwright-report/
+          retention-days: 30

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,98 @@
+# Integration E2E suite
+
+Runs Playwright against a real Yeti stack -- real ArangoDB, real API, real
+frontend, no mocked network requests -- unlike the frontend's own e2e suite
+(`dev/yeti-feeds-frontend/tests/e2e`), which deliberately mocks every
+`/api/v2/**` call and never starts a backend at all. This suite exists to
+catch the class of bug that suite structurally can't: real backend bugs,
+real auth flows, real timing/consistency issues across the stack.
+
+It's intentionally a *smoke* suite, not a mirror of the frontend's full
+component-level coverage: a handful of critical paths (login, create/tag/
+search/delete an observable) rather than all 17+ specs. Growing it is easy
+(see "Adding a spec" below) but the point is fast, high-value coverage for
+release confidence, not exhaustive UI regression testing -- that's what the
+mocked suite is for.
+
+## Running it
+
+```sh
+./run.sh
+```
+
+This builds `dev/yeti` and `dev/yeti-feeds-frontend` (as checked out
+locally -- whatever you have checked out is what gets tested), starts a
+fresh stack, seeds a test admin user, runs the suite, and tears everything
+down again regardless of outcome. Override the seeded credentials or target
+URL via env vars if needed:
+
+```sh
+TEST_USERNAME=myuser TEST_PASSWORD='...' BASE_URL=http://127.0.0.1:18080 ./run.sh
+```
+
+Requires Docker with Compose v2, and enough free disk to build both images
+(roughly 2-3GB net of layer caching).
+
+### Running it manually, step by step
+
+Useful when iterating on a spec, so you don't rebuild/reseed on every run:
+
+```sh
+cd integration-tests
+docker compose up -d --build --wait
+docker compose run --rm api create-user integration-test 'Integration-Test-Password-1!' --admin
+
+cd playwright
+npm ci
+npx playwright test                    # if your host can run Playwright browsers directly
+# otherwise, run inside the same container image CI uses:
+docker run --rm --network host -v "$(pwd)":/work -w /work \
+  -e BASE_URL=http://127.0.0.1:18080 \
+  -e TEST_USERNAME=integration-test \
+  -e TEST_PASSWORD='Integration-Test-Password-1!' \
+  mcr.microsoft.com/playwright:v1.61.1-jammy \
+  bash -c "npm ci && npx playwright test"
+
+# when done:
+cd .. && docker compose down --volumes --remove-orphans
+```
+
+The pinned `mcr.microsoft.com/playwright:v1.61.1-jammy` image ships browser
+binaries matching the exact `@playwright/test` version in
+`playwright/package.json` -- keep both in sync if you bump the dependency.
+A bare-host Playwright browser install isn't guaranteed to work (it doesn't
+on Debian 11, for instance).
+
+## Running in CI
+
+`.github/workflows/integration-e2e.yaml` is `workflow_dispatch`-only --
+it doesn't run on every PR, since it's a multi-container, real-database
+suite an order of magnitude slower than either repo's own test suite. Run
+it manually from the Actions tab, optionally pointing `yeti_ref`/
+`frontend_ref` at specific branches/tags/SHAs (defaults to `main` for
+both). **Run this before cutting a release**, pointed at the commits you're
+about to tag.
+
+## Known gotchas
+
+- **ArangoSearch views are eventually consistent**, same as in the
+  backend's own test suite -- searching for something you just created or
+  tagged may need a retry, not just a longer single wait (see
+  `tests/observable-lifecycle.spec.ts`'s search step for the pattern).
+  Deleting a *tagged* object in particular seems to widen this window well
+  past what's reasonable to poll for (observed >15s vs ~1-2s for an
+  untagged object) -- verify deletion via a direct API call instead of the
+  search view in that case (see the same spec's final step).
+- **`getByRole("dialog")`, not `.v-overlay--active`**, to target a dialog.
+  Against a real backend, save/create snackbars are genuinely visible (not
+  fast-forwarded like a mock) and also carry the `v-overlay--active` class,
+  making that selector ambiguous whenever a toast happens to be up.
+
+## Adding a spec
+
+Put it in `playwright/tests/`, reuse `tests/helpers.ts`'s `login()`. Specs
+run sequentially (`playwright.config.ts` sets `workers: 1`) because they
+share one real backend and database, unlike the frontend's isolated mocked
+tests -- keep that in mind if a new spec's data could collide with another
+spec's (e.g. use a unique value like `` `test-${Date.now()}` ``, as the
+existing lifecycle spec does).

--- a/integration-tests/docker-compose.yaml
+++ b/integration-tests/docker-compose.yaml
@@ -1,0 +1,56 @@
+name: yeti-integration
+
+services:
+  arangodb:
+    image: arangodb:3.11
+    environment:
+      - ARANGO_ROOT_PASSWORD=
+    healthcheck:
+      test: ["CMD-SHELL", "arangosh --server.endpoint tcp://127.0.0.1:8529 --server.username root --server.password \"$$ARANGO_ROOT_PASSWORD\" --javascript.execute-string 'db._version()' >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 10
+
+  redis:
+    image: redis:latest
+
+  api:
+    build:
+      context: ../dev/yeti
+      dockerfile: ./extras/docker/Dockerfile
+    command: ["webserver-prod"]
+    environment:
+      - YETI_REDIS_HOST=redis
+      - YETI_REDIS_PORT=6379
+      - YETI_REDIS_DATABASE=0
+      - YETI_ARANGODB_HOST=arangodb
+      - YETI_ARANGODB_PORT=8529
+      - YETI_ARANGODB_DATABASE=yeti
+      - YETI_ARANGODB_USERNAME=root
+      - YETI_ARANGODB_PASSWORD=
+      - YETI_AUTH_SECRET_KEY=integration-test-secret
+      - YETI_AUTH_ALGORITHM=HS256
+      - YETI_AUTH_ACCESS_TOKEN_EXPIRE_MINUTES=30
+      - YETI_AUTH_BROWSER_TOKEN_EXPIRE_MINUTES=43200
+      - YETI_AUTH_ENABLED=True
+      - YETI_SYSTEM_PLUGINS_PATH=./plugins
+    depends_on:
+      redis:
+        condition: service_started
+      arangodb:
+        condition: service_healthy
+    ports:
+      - 127.0.0.1:18000:8000
+
+  frontend:
+    build:
+      context: ../dev/yeti-feeds-frontend
+      dockerfile: ./docker/prod/Dockerfile
+    volumes:
+      - ./frontend-nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      api:
+        condition: service_started
+    ports:
+      - 127.0.0.1:18080:80

--- a/integration-tests/frontend-nginx.conf
+++ b/integration-tests/frontend-nginx.conf
@@ -1,0 +1,16 @@
+server {
+
+    root /www;
+
+    location /api/v2 {
+        proxy_pass http://api:8000;
+    }
+
+    location ~(^/docs|^/openapi.json) {
+        proxy_pass http://api:8000;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/integration-tests/playwright/.gitignore
+++ b/integration-tests/playwright/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/integration-tests/playwright/package-lock.json
+++ b/integration-tests/playwright/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "yeti-integration-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yeti-integration-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.61.1",
+        "@types/node": "^22.20.1",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/integration-tests/playwright/package.json
+++ b/integration-tests/playwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "yeti-integration-tests",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "@types/node": "^22.20.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/integration-tests/playwright/playwright.config.ts
+++ b/integration-tests/playwright/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  // Unlike the frontend's own mocked e2e suite, these tests share one real
+  // backend and database -- run sequentially to avoid cross-test interference
+  // (e.g. a search assertion racing another test's in-flight create).
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: "html",
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://127.0.0.1:18080",
+    trace: "on-first-retry"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/integration-tests/playwright/tests/helpers.ts
+++ b/integration-tests/playwright/tests/helpers.ts
@@ -1,0 +1,13 @@
+import { type Page, expect } from "@playwright/test";
+
+export const TEST_USERNAME = process.env.TEST_USERNAME ?? "integration-test";
+export const TEST_PASSWORD = process.env.TEST_PASSWORD ?? "Integration-Test-Password-1!";
+
+/** Logs in through the real login form against the real backend. */
+export async function login(page: Page): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Username").fill(TEST_USERNAME);
+  await page.getByLabel("Password").fill(TEST_PASSWORD);
+  await page.getByRole("button", { name: "Log in" }).click();
+  await expect(page).toHaveURL(/\/observables/);
+}

--- a/integration-tests/playwright/tests/login.spec.ts
+++ b/integration-tests/playwright/tests/login.spec.ts
@@ -1,0 +1,8 @@
+import { test } from "@playwright/test";
+import { login } from "./helpers";
+
+/** Fast, isolated check that real auth works end to end (real /auth/token,
+ * real /auth/me) before the heavier lifecycle test runs. */
+test("logs in against the real backend", async ({ page }) => {
+  await login(page);
+});

--- a/integration-tests/playwright/tests/observable-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/observable-lifecycle.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * End-to-end smoke test against a real Yeti stack (real ArangoDB, real API,
+ * no mocked routes): create a hostname observable through the UI, confirm it
+ * persisted by searching for it, tag it, then delete it and confirm it's
+ * gone. Exercises the real /observables POST, GET, /tag, DELETE, and /search
+ * endpoints end to end, unlike the frontend's own mocked e2e suite.
+ */
+test("create, search, tag, and delete an observable", async ({ page }) => {
+  const hostname = `integration-test-${Date.now()}.example.com`;
+
+  await login(page);
+
+  // --- Create ---
+  await page.goto("/observables");
+  await page.getByRole("button", { name: "New Observable" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Hostname" }).first().click();
+
+  // getByRole("dialog") (not .v-overlay--active) -- against a real backend a
+  // save/create snackbar is genuinely visible and also carries
+  // v-overlay--active, making that class ambiguous.
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("New Hostname")).toBeVisible();
+  await newDialog.getByLabel("Value").fill(hostname);
+  await newDialog.getByRole("button", { name: "Save" }).click();
+
+  // On success, NewObject redirects to the created object's details page.
+  await expect(page).toHaveURL(/\/observables\/[\w-]+$/);
+  await expect(page.locator(".observable-value")).toHaveText(hostname);
+  const observableId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Tag ---
+  const tagBox = page.locator(".v-combobox input").first();
+  await tagBox.fill("integration-test-tag");
+  await tagBox.press("Enter");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("integration-test-tag")).toBeVisible();
+
+  // --- Search ---
+  // ArangoSearch views are eventually consistent (same reason the backend's
+  // own test suite waits after tagging before searching) -- retry the search
+  // itself, not just the assertion, until the view has caught up.
+  await page.goto("/observables");
+  const searchInput = page.getByRole("textbox", { name: /Search observables/ });
+  await expect(async () => {
+    await searchInput.fill(hostname);
+    await searchInput.press("Enter");
+    await expect(page.locator("tbody tr")).toHaveCount(1);
+    await expect(page.locator("tbody tr").first()).toContainText("integration-test-tag");
+  }).toPass({ timeout: 10_000 });
+  await expect(page.locator("tbody tr").first()).toContainText(hostname);
+
+  // --- Delete ---
+  await page.locator("tbody tr").first().getByRole("link", { name: hostname }).click();
+  await expect(page).toHaveURL(/\/observables\/[\w-]+$/);
+  await page.getByRole("button", { name: "Edit" }).click();
+
+  const editDialog = page.getByRole("dialog");
+  await editDialog.getByRole("button", { name: "Delete object" }).click();
+
+  const confirmDialog = page.getByRole("dialog").last();
+  await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+  // --- Confirm gone ---
+  // Query the API directly rather than the search view: tagging appears to
+  // push the view's eventual-consistency window out well past what's
+  // reasonable to poll for in a smoke test (observed >15s in practice, vs
+  // ~1-2s for an untagged object), even though the underlying document is
+  // deleted immediately -- a direct GET reflects that right away.
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const response = await page.request.get(`/api/v2/observables/${observableId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  expect(response.status()).toBe(404);
+});

--- a/integration-tests/playwright/tsconfig.json
+++ b/integration-tests/playwright/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts"]
+}

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Spins up a fresh Yeti stack (built from local source), seeds a test user,
+# runs the Playwright integration suite against it, and tears everything
+# down again -- pass or fail.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export TEST_USERNAME="${TEST_USERNAME:-integration-test}"
+export TEST_PASSWORD="${TEST_PASSWORD:-Integration-Test-Password-1!}"
+export BASE_URL="${BASE_URL:-http://127.0.0.1:18080}"
+
+cleanup() {
+  echo "--- Tearing down integration stack ---"
+  docker compose down --volumes --remove-orphans
+}
+trap cleanup EXIT
+
+echo "--- Building and starting the integration stack ---"
+docker compose up -d --build --wait
+
+echo "--- Seeding test user ($TEST_USERNAME) ---"
+docker compose run --rm api create-user "$TEST_USERNAME" "$TEST_PASSWORD" --admin
+
+echo "--- Running Playwright integration suite ---"
+# Run inside the official Playwright image rather than on the host: it ships
+# browser binaries matching the pinned @playwright/test version, which a bare
+# host install can't guarantee (and outright fails on some OSes/versions).
+# Keep this tag in sync with the @playwright/test version in
+# playwright/package.json.
+docker run --rm \
+  --network host \
+  -v "$(pwd)/playwright":/work -w /work \
+  -e BASE_URL \
+  -e TEST_USERNAME \
+  -e TEST_PASSWORD \
+  -e HOME=/root \
+  mcr.microsoft.com/playwright:v1.61.1-jammy \
+  bash -c "npm ci && npx playwright test"


### PR DESCRIPTION
## Summary

We have solid frontend e2e coverage (`dev/yeti-feeds-frontend/tests/e2e`),
but it only ever exercises the frontend in isolation — a shared fixture
aborts every `/api/v2/**` request by default, and CI never starts a
backend at all. That's a valuable component/UI regression suite, but it
would not have caught any of the real backend bugs found and fixed this
session (auth 500s on non-expiring tokens, the RBAC async bug, DB races,
the empty-Feeds startup race) — none of those are UI bugs.

This adds a second, smaller suite: Playwright driving a real Yeti stack
(real ArangoDB, real API, real frontend, zero mocked routes) via
docker-compose, building both `yeti` and `yeti-feeds-frontend` from local
source rather than pulling published images — so it tests what's actually
about to be released.

## What it covers

Deliberately a **smoke** suite, not a mirror of the mocked suite's full
coverage: login, then create → tag → search → delete an observable
through the real UI. Exercises the real POST/GET/PATCH/DELETE/search/tag
endpoints end to end. Easy to grow; the goal is fast, high-value coverage
for release confidence, not exhaustive UI regression testing.

## Two real things this surfaced

Both documented in the README and in code comments so they don't have to
be rediscovered:

- **A real save/create snackbar is genuinely visible against a live
  backend** and carries the same `v-overlay--active` class as the
  New/Edit dialogs, making that selector ambiguous — only shows up with
  real network timing, never in the mocked suite. `getByRole("dialog")`
  doesn't have this problem.
- **ArangoSearch views are eventually consistent** (same reason the
  backend's own test suite waits after tagging before searching) — and
  deleting a *tagged* object widens that window well past what's
  reasonable to poll for (observed >15s vs ~1-2s for an untagged object),
  even though the underlying document is deleted immediately. The suite
  verifies deletion via a direct API call in that case, not the search
  view.

## Where it lives and when it runs

- Lives in `yeti-docker` (this repo) since it already knows how to wire
  both sibling repos together — no cross-repo checkout gymnastics needed
  in either `yeti`'s or `yeti-feeds-frontend`'s own CI.
- `workflow_dispatch` only, with configurable `yeti_ref`/`frontend_ref`
  inputs (default `main`) — **not** on every PR, since it's a
  multi-container, real-database suite an order of magnitude slower than
  either repo's own test suite. Intended to be run manually before
  cutting a release.
- Also runnable locally via `integration-tests/run.sh` (build, seed,
  test, teardown — regardless of outcome).

## Test plan

- [x] Ran `integration-tests/run.sh` end-to-end multiple times locally
      (4 consecutive full runs) — both specs pass reliably.
- [x] Verified the workflow YAML parses correctly.
- [x] Confirmed `.gitignore` keeps `node_modules/`, `playwright-report/`,
      `test-results/` out of the repo; `package-lock.json` is committed
      (matching the frontend repo's own convention, and required for
      `npm ci`).