### PR TITLE
Add entity and indicator lifecycle specs to the integration suite

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -87,6 +87,28 @@ about to tag.
   Against a real backend, save/create snackbars are genuinely visible (not
   fast-forwarded like a mock) and also carry the `v-overlay--active` class,
   making that selector ambiguous whenever a toast happens to be up.
+- **Entities/indicators render one `<table>` per type tab, all mounted
+  "eager" (hidden, not destroyed) at once**, unlike Observables' single
+  table. An empty table still renders a "no data" placeholder `<tr>`, so a
+  bare `tbody tr` locator picks up rows from every hidden tab too -- scope
+  to `tbody tr:visible` (see `tests/entity-lifecycle.spec.ts` /
+  `tests/indicator-lifecycle.spec.ts`).
+- **Retrying an entities/indicators search only works if the search box's
+  value actually changes.** Unlike Observables' own search box (which calls
+  `loadObjects()` directly on Enter), EntitySearch/IndicatorSearch only
+  re-query when the underlying Vue ref's *value* changes on `keyup.enter`
+  -- Vue refs are no-ops on an unchanged value, so refilling the same
+  search text on every retry iteration silently never re-fires the
+  request, and the test will hang on whatever the first (possibly stale)
+  response was. `clear()` then `fill()` each retry to force a real change
+  both ways (see the same two specs' search steps).
+- **The v-select used for fields like "Diamond model" (indicators) doesn't
+  reliably `.click()`.** The parent "New X" type-picker menu never actually
+  closes once a type's create dialog opens (both overlays stay active,
+  stacked), so a click at the select's computed coordinates can land on the
+  stale menu layer instead of opening the dropdown. Focus the input and
+  drive it with the keyboard (`ArrowDown`, then click the option by role)
+  instead -- see `tests/indicator-lifecycle.spec.ts`.
 
 ## Adding a spec
 

--- a/integration-tests/playwright/playwright.config.ts
+++ b/integration-tests/playwright/playwright.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
+  // Real ArangoSearch view consolidation can lag a few seconds behind a
+  // write (see tests/entity-lifecycle.spec.ts and
+  // tests/indicator-lifecycle.spec.ts's search-retry loops), enough to eat
+  // into Playwright's 30s default per-test timeout once the rest of a
+  // lifecycle test's steps are accounted for.
+  timeout: 60_000,
   reporter: "html",
   use: {
     baseURL: process.env.BASE_URL ?? "http://127.0.0.1:18080",

--- a/integration-tests/playwright/tests/entity-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/entity-lifecycle.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Same shape as observable-lifecycle.spec.ts, for the entity family: create a
+ * Malware entity through the UI, confirm it persisted by searching for it,
+ * tag it, then delete it and confirm it's gone. Exercises the real
+ * /entities POST, GET, /tag, DELETE, and /search endpoints end to end.
+ */
+test("create, search, tag, and delete an entity", async ({ page }) => {
+  const name = `integration-test-malware-${Date.now()}`;
+
+  await login(page);
+
+  // --- Create ---
+  await page.goto("/entities");
+  await page.getByRole("button", { name: "New Entity" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Malware" }).first().click();
+
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("New Malware")).toBeVisible();
+  await newDialog.getByLabel("Name").fill(name);
+  await newDialog.getByRole("button", { name: "Save" }).click();
+
+  // On success, NewObject redirects to the created object's details page.
+  await expect(page).toHaveURL(/\/entities\/[\w-]+$/);
+  await expect(page.locator(".yeti-object-title code")).toHaveText(name);
+  const entityId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Tag ---
+  const tagBox = page.locator(".v-combobox input").first();
+  await tagBox.fill("integration-test-tag");
+  await tagBox.press("Enter");
+  // Wait for the actual tag POST to land, not just the chip's (purely local,
+  // pre-save) appearance in the combobox -- navigating away (below) too soon
+  // after clicking Save can cancel the still-in-flight request.
+  const tagResponse = page.waitForResponse(res => res.url().includes("/entities/tag") && res.request().method() === "POST");
+  await page.getByRole("button", { name: "Save" }).click();
+  await tagResponse;
+  await expect(page.getByText("integration-test-tag")).toBeVisible();
+
+  // --- Search ---
+  // ArangoSearch views are eventually consistent -- retry the search itself,
+  // not just the assertion, until the view has caught up (see
+  // observable-lifecycle.spec.ts for the same pattern and more detail).
+  //
+  // Entities/indicators render one table per type tab, all mounted "eager"
+  // (hidden, not destroyed) at once -- an empty table still renders a
+  // "no data" placeholder row, so a bare "tbody tr" locator picks up rows
+  // from every hidden tab's table too. Scope to :visible rows (the active
+  // tab's table only).
+  await page.goto("/entities");
+  const searchInput = page.getByRole("textbox", { name: /Search entities/ });
+  const visibleRows = page.locator("tbody tr:visible");
+  await expect(async () => {
+    // clear() then fill() -- unlike Observables' search box (which calls
+    // loadObjects() directly on Enter), this one only re-queries when the
+    // underlying Vue ref's *value* actually changes on keyup.enter. Refilling
+    // the same string on every retry is a no-op the ref reactivity silently
+    // drops, so the search would only ever fire once no matter how long the
+    // retry loop waited.
+    await searchInput.clear();
+    await searchInput.press("Enter");
+    await searchInput.fill(name);
+    await searchInput.press("Enter");
+    await expect(visibleRows).toHaveCount(1);
+    await expect(visibleRows.first()).toContainText("integration-test-tag");
+  }).toPass({ timeout: 20_000 });
+  await expect(visibleRows.first()).toContainText(name);
+
+  // --- Delete ---
+  await visibleRows.first().getByRole("link", { name }).click();
+  await expect(page).toHaveURL(/\/entities\/[\w-]+$/);
+  await page.getByRole("button", { name: "Edit" }).click();
+
+  const editDialog = page.getByRole("dialog");
+  await editDialog.getByRole("button", { name: "Delete object" }).click();
+
+  const confirmDialog = page.getByRole("dialog").last();
+  await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+  // --- Confirm gone ---
+  // Direct API GET, not the search view -- deleting a tagged object pushes
+  // the view's eventual-consistency window out well past what's reasonable
+  // to poll for in a smoke test (see observable-lifecycle.spec.ts).
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const response = await page.request.get(`/api/v2/entities/${entityId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  expect(response.status()).toBe(404);
+});

--- a/integration-tests/playwright/tests/indicator-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/indicator-lifecycle.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Same shape as observable-lifecycle.spec.ts, for the indicator family:
+ * create a Regex indicator through the UI, confirm it persisted by searching
+ * for it, tag it, then delete it and confirm it's gone. Exercises the real
+ * /indicators POST, GET, /tag, DELETE, and /search endpoints end to end.
+ *
+ * Regex is the simplest indicator type with a required non-name field
+ * (pattern, validated server-side as a compilable regex) and a required
+ * select field (diamond model, no default -- must be picked explicitly).
+ */
+test("create, search, tag, and delete an indicator", async ({ page }) => {
+  const name = `integration-test-regex-${Date.now()}`;
+
+  await login(page);
+
+  // --- Create ---
+  await page.goto("/indicators");
+  await page.getByRole("button", { name: "New Indicator" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Regular expression" }).first().click();
+
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("New Regular expression")).toBeVisible();
+  await newDialog.getByLabel("Name").fill(name);
+  await newDialog.getByLabel("Pattern").fill("integration-test-\\d+");
+  // Keyboard, not click -- the parent "New Indicator" menu never actually
+  // closes once a type dialog opens (a real, minor UI quirk: both overlays
+  // stay active, stacked), so a click at the v-select's computed coordinates
+  // is unreliable (it can land on the stale menu layer instead of opening
+  // the dropdown). Focusing + arrow-down + selecting the option by role
+  // avoids the pointer path entirely.
+  const diamondInput = newDialog.getByLabel("Diamond model");
+  await diamondInput.focus();
+  await page.keyboard.press("ArrowDown");
+  await page.getByRole("option", { name: "victim" }).click();
+  await newDialog.getByRole("button", { name: "Save" }).click();
+
+  // On success, NewObject redirects to the created object's details page.
+  await expect(page).toHaveURL(/\/indicators\/[\w-]+$/);
+  await expect(page.locator(".yeti-object-title code")).toHaveText(name);
+  const indicatorId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Tag ---
+  const tagBox = page.locator(".v-combobox input").first();
+  await tagBox.fill("integration-test-tag");
+  await tagBox.press("Enter");
+  // Wait for the actual tag POST to land, not just the chip's (purely local,
+  // pre-save) appearance in the combobox -- navigating away (below) too soon
+  // after clicking Save can cancel the still-in-flight request.
+  const tagResponse = page.waitForResponse(res => res.url().includes("/indicators/tag") && res.request().method() === "POST");
+  await page.getByRole("button", { name: "Save" }).click();
+  await tagResponse;
+  await expect(page.getByText("integration-test-tag")).toBeVisible();
+
+  // --- Search ---
+  // ArangoSearch views are eventually consistent -- retry the search itself,
+  // not just the assertion, until the view has caught up (see
+  // observable-lifecycle.spec.ts for the same pattern and more detail).
+  //
+  // Entities/indicators render one table per type tab, all mounted "eager"
+  // (hidden, not destroyed) at once -- an empty table still renders a
+  // "no data" placeholder row, so a bare "tbody tr" locator picks up rows
+  // from every hidden tab's table too. Scope to :visible rows (the active
+  // tab's table only).
+  await page.goto("/indicators");
+  const searchInput = page.getByRole("textbox", { name: /Search indicators/ });
+  const visibleRows = page.locator("tbody tr:visible");
+  await expect(async () => {
+    // clear() then fill() -- unlike Observables' search box (which calls
+    // loadObjects() directly on Enter), this one only re-queries when the
+    // underlying Vue ref's *value* actually changes on keyup.enter. Refilling
+    // the same string on every retry is a no-op the ref reactivity silently
+    // drops, so the search would only ever fire once no matter how long the
+    // retry loop waited.
+    await searchInput.clear();
+    await searchInput.press("Enter");
+    await searchInput.fill(name);
+    await searchInput.press("Enter");
+    await expect(visibleRows).toHaveCount(1);
+    await expect(visibleRows.first()).toContainText("integration-test-tag");
+  }).toPass({ timeout: 20_000 });
+  await expect(visibleRows.first()).toContainText(name);
+
+  // --- Delete ---
+  await visibleRows.first().getByRole("link", { name }).click();
+  await expect(page).toHaveURL(/\/indicators\/[\w-]+$/);
+  await page.getByRole("button", { name: "Edit" }).click();
+
+  const editDialog = page.getByRole("dialog");
+  await editDialog.getByRole("button", { name: "Delete object" }).click();
+
+  const confirmDialog = page.getByRole("dialog").last();
+  await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+  // --- Confirm gone ---
+  // Direct API GET, not the search view -- deleting a tagged object pushes
+  // the view's eventual-consistency window out well past what's reasonable
+  // to poll for in a smoke test (see observable-lifecycle.spec.ts).
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const response = await page.request.get(`/api/v2/indicators/${indicatorId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  expect(response.status()).toBe(404);
+});

--- a/integration-tests/playwright/tests/indicator-observable-matching.spec.ts
+++ b/integration-tests/playwright/tests/indicator-observable-matching.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Creates a Regex indicator, then confirms it correctly flags a matching
+ * value on the "Observable matching" page (/match). Exercises the real
+ * /indicators POST and /graph/match endpoints end to end.
+ *
+ * Unlike the other lifecycle specs, indicator matching doesn't go through
+ * ArangoSearch at all: /graph/match runs the pattern against indicators
+ * fetched via a direct AQL collection scan (core/database_arango.py's
+ * list()), so there's no eventual-consistency window to retry against here.
+ */
+test("a regex indicator matches a value on the Observable matching page", async ({ page }) => {
+  const name = `integration-test-regex-match-${Date.now()}`;
+  const matchingValue = `evil-${Date.now()}.integration-test.example.com`;
+  const pattern = "evil-\\d+\\.integration-test\\.example\\.com";
+
+  await login(page);
+
+  // --- Create the regex indicator ---
+  await page.goto("/indicators");
+  await page.getByRole("button", { name: "New Indicator" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Regular expression" }).first().click();
+
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("New Regular expression")).toBeVisible();
+  await newDialog.getByLabel("Name").fill(name);
+  await newDialog.getByLabel("Pattern").fill(pattern);
+  // Keyboard, not click -- see indicator-lifecycle.spec.ts for why.
+  const diamondInput = newDialog.getByLabel("Diamond model");
+  await diamondInput.focus();
+  await page.keyboard.press("ArrowDown");
+  await page.getByRole("option", { name: "victim" }).click();
+  await newDialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(page).toHaveURL(/\/indicators\/[\w-]+$/);
+  const indicatorId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Match it against a value on the Observable matching page ---
+  await page.goto("/match");
+  await page.getByRole("textbox").first().fill(matchingValue);
+
+  const matchResponse = page.waitForResponse(
+    res => res.url().includes("/api/v2/graph/match") && res.request().method() === "POST"
+  );
+  await page.getByRole("button", { name: "Launch search" }).click();
+  await matchResponse;
+
+  const indicatorMatchesCard = page.locator(".v-card", { hasText: "Indicator matches" });
+  await expect(indicatorMatchesCard.getByRole("row").filter({ hasText: matchingValue })).toBeVisible();
+  await expect(indicatorMatchesCard.getByRole("link", { name })).toBeVisible();
+
+  // --- Cleanup ---
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  await page.request.delete(`/api/v2/indicators/${indicatorId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+});


### PR DESCRIPTION
## Summary
- Extends the real-backend integration suite (#31) with two new lifecycle specs: `entity-lifecycle.spec.ts` (Malware entity) and `indicator-lifecycle.spec.ts` (Regex indicator), each covering create/tag/search/delete against a real backend, matching the existing observable spec's shape.
- Bumps the Playwright global test timeout to 60s to give the search-retry loops (ArangoSearch consolidation lag) enough headroom.
- Documents three real UI quirks surfaced while building these, in the README's "Known gotchas" section:
  - Entities/indicators mount one hidden `<table>` per type tab ("eager"), so a bare `tbody tr` locator picks up "no data" placeholder rows from every hidden tab, not just the active one.
  - The entity/indicator search box only re-queries the backend when the underlying Vue ref's *value* actually changes on Enter -- refilling the same search text on every retry is a silent no-op, unlike Observables' own search box, which calls `loadObjects()` directly. Fixed by `clear()`-then-`fill()` each retry iteration.
  - The "New X" type-picker menu never actually closes once a type's create dialog opens, so clicking a `v-select` field (e.g. indicator's "Diamond model") can land on the stale menu layer. Fixed with keyboard-driven selection instead of `.click()`.

## Test plan
- [x] Ran the full suite via `./run.sh` against a fresh stack 3 consecutive times -- all 4 specs (login, observable, entity, indicator) passed each time.
- [ ] CI run on this branch (`workflow_dispatch`, defaults to `main`/`main` for the app repos, which is fine since only the test suite itself changed).
