### PR TITLE
Add DFIQ scenario/question integration specs

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -134,6 +134,26 @@ about to tag.
   object's own "Info" side panel, a plain (non-data-table) `<v-table>`
   that's always on the page and would otherwise leak its own rows into a
   bare `tbody tr` match.
+- **DFIQ objects (Scenario/Facet/Question) go through a completely
+  different create/edit dialog** (`EditDFIQObject.vue`, YAML-backed) than
+  everything else (`NewObject.vue`). Typed field values flow into an
+  in-memory YAML document that's re-validated against
+  `/api/v2/dfiq/validate` on a 500ms debounce, and Save stays disabled
+  until that comes back valid -- wait for Save to become enabled with a
+  generous timeout (e.g. 10s) rather than assuming it's immediate, see
+  `tests/dfiq-scenario.spec.ts`.
+- **The DFIQ tree's "new facet"/"new question" buttons on each node are
+  hidden until that row is hovered** (a real CSS `:hover` reveal, not a
+  click-to-expand toggle) -- `.hover()` the row before trying to click one,
+  see `tests/dfiq-scenario-inline-question.spec.ts`.
+- **The "Parents" field on a Question/Facet loads its options once, when
+  the dialog mounts** (`EditDFIQObject.vue`'s `loadPossibleParents()`),
+  not per keystroke like other search boxes in this app -- so there's a
+  real ArangoSearch-view consistency window if you just created the
+  parent scenario/facet moments earlier, and re-typing in the field won't
+  help (the underlying fetch never re-runs). Poll the search API directly
+  before opening the dialog instead of retrying inside it, see
+  `tests/dfiq-question-multiple-parents.spec.ts`.
 
 ## Adding a spec
 

--- a/integration-tests/playwright/tests/dfiq-question-multiple-parents.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-question-multiple-parents.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Creates two DFIQ Scenarios, then a Question (via the top-level "New DFIQ
+ * object" flow, not the tree's inline create) associated to *both* via the
+ * "Parents" field. Confirms the question appears under both scenarios'
+ * DFIQ trees.
+ */
+test("create a question and associate it to two scenarios via the Parents field", async ({ page }) => {
+  const scenarioAName = `integration-test-scenario-a-${Date.now()}`;
+  const scenarioBName = `integration-test-scenario-b-${Date.now()}`;
+  const questionName = `integration-test-question-${Date.now()}`;
+
+  await login(page);
+
+  async function createScenario(name: string): Promise<string> {
+    await page.goto("/dfiq");
+    await page.getByRole("button", { name: "New DFIQ object" }).click();
+    await page.getByRole("listitem").filter({ hasText: "Scenario" }).first().click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Creating DFIQ scenario")).toBeVisible();
+    await dialog.getByLabel("Name").fill(name);
+    await expect(dialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+    await dialog.getByRole("button", { name: "Save" }).click();
+    await expect(page).toHaveURL(/\/dfiq\/[\w-]+$/);
+    return new URL(page.url()).pathname.split("/").pop() as string;
+  }
+
+  const scenarioAId = await createScenario(scenarioAName);
+  const scenarioBId = await createScenario(scenarioBName);
+
+  // The "Parents" field's options come from a single /api/v2/dfiq/search
+  // done once when the dialog mounts (not re-queried per keystroke), so --
+  // unlike the tree's inline-create path -- there's a real ArangoSearch-view
+  // consistency window here: make sure both scenarios are actually
+  // searchable before opening the dialog, since re-typing later won't
+  // re-trigger that initial fetch.
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  await expect(async () => {
+    const response = await page.request.post("/api/v2/dfiq/search", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: { query: { name: "integration-test-scenario-" }, count: 20, page: 0, sorting: [] }
+    });
+    const { dfiq: matches } = await response.json();
+    const names = matches.map((m: { name: string }) => m.name);
+    expect(names).toEqual(expect.arrayContaining([scenarioAName, scenarioBName]));
+  }).toPass({ timeout: 20_000 });
+
+  // --- Create the question, linking both scenarios via "Parents" ---
+  await page.goto("/dfiq");
+  await page.getByRole("button", { name: "New DFIQ object" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Question" }).first().click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Creating DFIQ question")).toBeVisible();
+  await dialog.getByLabel("Name").fill(questionName);
+
+  const parentsField = dialog.getByLabel("Parents");
+  await parentsField.click();
+  await parentsField.fill(scenarioAName);
+  await page.getByRole("option", { name: scenarioAName }).click();
+  await parentsField.fill(scenarioBName);
+  await page.getByRole("option", { name: scenarioBName }).click();
+  await expect(dialog.getByText(scenarioAName)).toBeVisible();
+  await expect(dialog.getByText(scenarioBName)).toBeVisible();
+
+  await expect(dialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await dialog.getByRole("button", { name: "Save" }).click();
+  await expect(page).toHaveURL(/\/dfiq\/[\w-]+$/);
+  const questionId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Confirm the question appears under both scenarios' DFIQ trees ---
+  for (const scenarioId of [scenarioAId, scenarioBId]) {
+    await page.goto(`/dfiq/${scenarioId}`);
+    await page.getByRole("tab", { name: /DFIQ tree/ }).click();
+    const questionRow = page.locator("li").filter({ hasText: questionName }).first();
+    await expect(questionRow).toBeVisible();
+  }
+
+  // --- Cleanup ---
+  await page.request.delete(`/api/v2/dfiq/${questionId}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  await page.request.delete(`/api/v2/dfiq/${scenarioAId}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  await page.request.delete(`/api/v2/dfiq/${scenarioBId}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+});

--- a/integration-tests/playwright/tests/dfiq-scenario-inline-question.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-scenario-inline-question.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Creates a DFIQ Scenario, then -- from the scenario's own "DFIQ tree" tab
+ * (DFIQTree.vue's inline "new question" button, not the top-level "New DFIQ
+ * object" flow) -- creates a Question as its child. Confirms the question
+ * shows up nested under the scenario in the tree.
+ */
+test("create a scenario, then add a question inline from its DFIQ tree", async ({ page }) => {
+  const scenarioName = `integration-test-scenario-${Date.now()}`;
+  const questionName = `integration-test-question-${Date.now()}`;
+
+  await login(page);
+
+  // --- Create the scenario ---
+  await page.goto("/dfiq");
+  await page.getByRole("button", { name: "New DFIQ object" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Scenario" }).first().click();
+
+  const newScenarioDialog = page.getByRole("dialog");
+  await expect(newScenarioDialog.getByText("Creating DFIQ scenario")).toBeVisible();
+  await newScenarioDialog.getByLabel("Name").fill(scenarioName);
+  await expect(newScenarioDialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await newScenarioDialog.getByRole("button", { name: "Save" }).click();
+  await expect(page).toHaveURL(/\/dfiq\/[\w-]+$/);
+  const scenarioId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Add a question inline, from the DFIQ tree tab ---
+  await page.getByRole("tab", { name: /DFIQ tree/ }).click();
+  const scenarioRow = page.locator("li").filter({ hasText: scenarioName }).first();
+  // The "new facet"/"new question" buttons are hidden until the row is
+  // hovered (CSS `li:hover > span > .item-controls`), matching the DFIQ
+  // tree's own real-user interaction model.
+  await scenarioRow.hover();
+  await scenarioRow.getByRole("button", { name: "new question" }).click();
+
+  const newQuestionDialog = page.getByRole("dialog").last();
+  await expect(newQuestionDialog.getByText("Creating DFIQ question")).toBeVisible();
+  await expect(newQuestionDialog.getByText(`pre-populated from scenario "${scenarioName}"`)).toBeVisible();
+  await newQuestionDialog.getByLabel("Name").fill(questionName);
+  await expect(newQuestionDialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await newQuestionDialog.getByRole("button", { name: "Save" }).click();
+
+  // No redirect for the inline-create path -- the dialog just closes and the
+  // (already-mounted, eager) top-level tree refetches via the DFIQupdated
+  // event bus, so the new question should appear nested under the scenario
+  // without a page reload.
+  await expect(newQuestionDialog).toBeHidden();
+  const questionRow = page.locator("li").filter({ hasText: questionName }).first();
+  await expect(questionRow).toBeVisible();
+
+  // --- Cleanup ---
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const searchResponse = await page.request.post("/api/v2/dfiq/search", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    data: { query: { name: questionName }, count: 10, page: 0, sorting: [] }
+  });
+  const { dfiq: questionMatches } = await searchResponse.json();
+  for (const match of questionMatches) {
+    await page.request.delete(`/api/v2/dfiq/${match.id}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  }
+  await page.request.delete(`/api/v2/dfiq/${scenarioId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+});

--- a/integration-tests/playwright/tests/dfiq-scenario.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-scenario.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Creates a DFIQ Scenario through the top-level "New DFIQ object" flow
+ * (EditDFIQObject.vue, not the generic NewObject.vue) and confirms it
+ * persisted. Exercises the real /dfiq/validate and /dfiq/from_yaml
+ * endpoints end to end.
+ */
+test("create a DFIQ scenario", async ({ page }) => {
+  const scenarioName = `integration-test-scenario-${Date.now()}`;
+
+  await login(page);
+
+  await page.goto("/dfiq");
+  await page.getByRole("button", { name: "New DFIQ object" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Scenario" }).first().click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Creating DFIQ scenario")).toBeVisible();
+  await dialog.getByLabel("Name").fill(scenarioName);
+
+  // The form doesn't save the entered fields directly -- they flow into an
+  // in-memory YAML document that's re-validated against /api/v2/dfiq/validate
+  // on a 500ms debounce, and Save stays disabled until that comes back valid.
+  await expect(dialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(page).toHaveURL(/\/dfiq\/[\w-]+$/);
+  const scenarioId = new URL(page.url()).pathname.split("/").pop();
+  await expect(page.locator(".yeti-object-title code")).toHaveText(scenarioName);
+
+  // --- Confirm gone after delete ---
+  await page.getByRole("button", { name: "Edit" }).click();
+  const editDialog = page.getByRole("dialog");
+  await expect(editDialog.getByText("Editing DFIQ scenario")).toBeVisible();
+  await editDialog.getByRole("button", { name: "Delete object" }).click();
+  const confirmDialog = page.getByRole("dialog").last();
+  await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const response = await page.request.get(`/api/v2/dfiq/${scenarioId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  expect(response.status()).toBe(404);
+});

--- a/integration-tests/playwright/tests/entity-indicator-link.spec.ts
+++ b/integration-tests/playwright/tests/entity-indicator-link.spec.ts
@@ -56,23 +56,15 @@ test("link an entity and an indicator, and confirm they appear in each other's n
   await expect(linkDialog.getByText(`New link for ${entityName}`)).toBeVisible();
   const linkTargetSearch = linkDialog.getByRole("combobox", { name: "Search for entities or indicators" });
   const saveLinkButton = linkDialog.getByRole("button", { name: "Save" });
-  // Each search result is a v-list-item carrying role="option" itself, but
-  // wrapping *two* buttons (the item's own name, and a separate "details"
-  // link) -- Playwright's accessible-name computation for that option
-  // doesn't reliably match on just the item's name text (it can silently
-  // resolve to zero elements). Match by raw text via the [role="option"]
-  // attribute selector instead, and click the inner name button
-  // specifically, not the option/list-item wrapper as a whole.
-  //
   // The autocomplete's own /entities, /indicators, /dfiq searches go
   // through the same eventually-consistent ArangoSearch views as
   // everywhere else -- retry until the freshly-created indicator actually
   // shows up and the click sticks (Save reports the target as picked).
   await expect(async () => {
     await linkTargetSearch.fill(indicatorName);
-    const option = page.locator('[role="option"]').filter({ hasText: indicatorName });
+    const option = page.getByRole("option", { name: indicatorName });
     await expect(option).toBeVisible();
-    await option.getByRole("button").first().click();
+    await option.click();
     await expect(saveLinkButton).toBeEnabled();
   }).toPass({ timeout: 20_000 });
 


### PR DESCRIPTION
## Summary
Three new specs covering the DFIQ scenario+question creation flows, as requested:
- **`dfiq-scenario.spec.ts`** -- create a Scenario through the top-level "New DFIQ object" flow, confirm it persists, then delete it.
- **`dfiq-scenario-inline-question.spec.ts`** -- create a Scenario, then add a Question as its child entirely from the scenario's own "DFIQ tree" tab (the tree's inline "new question" button), confirming it appears nested under the scenario without a page reload.
- **`dfiq-question-multiple-parents.spec.ts`** -- create two Scenarios, then a Question (via the top-level flow) associated to both via the "Parents" multi-select field, confirming it shows up under both scenarios' trees.

**Depends on** yeti-feeds-frontend#299 (still open): building the first spec surfaced a real bug -- `DFIQSearch.vue`'s "New DFIQ object" menu used `<edit-DFIQ-object>` in its template without ever importing the component, so creating **any** top-level Scenario/Facet/Question rendered a completely empty, non-functional dialog. Fixed there, not in this PR.

Also fixes `entity-indicator-link.spec.ts`, which broke as a direct, expected consequence of yeti-feeds-frontend#298 (merged earlier this session): its workaround for the old two-button option structure -- clicking "the first button inside the option" -- now clicks the unrelated "details" link instead of selecting the item, since #298's fix merged the name button into the option element itself. Simplified to the plain `getByRole("option", { name })` locator that fix was meant to enable.

New README gotchas: DFIQ objects use a different (YAML-backed, debounce-validated) create dialog than everything else; the DFIQ tree's "new X" buttons are hidden until their row is hovered; and the "Parents" field's options load once on dialog mount (not per keystroke), so it needs a pre-flight API poll rather than an in-dialog retry.

## Test plan
- [x] All 3 new specs pass standalone, 3 runs each, against fresh stacks built from yeti-feeds-frontend#299.
- [x] Full 9-spec suite passes together.
- [x] Full fresh `run.sh` build (matching CI) -- 9/9 pass.
