### PR TITLE
chore: normalize sibling workspace orchestration

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,11 +15,18 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out yeti-docker
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
+      - name: Validate shell and Compose contracts
+        run: |
+          bash -n dev/init.sh prod/init.sh integration-tests/run.sh tests/*.sh tests/fixtures/*
+          shellcheck dev/init.sh prod/init.sh integration-tests/run.sh tests/*.sh tests/fixtures/*
+          ./tests/integration-port-contract.sh
+          ./tests/production-env-contract.sh
       - name: Create CI environment from safe defaults
         run: |
           install -m 600 prod/.env.example prod/.env

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,8 @@
 name: Docker prod test
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -10,10 +13,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out yeti-docker
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Create CI environment from safe defaults
+        run: |
+          cp prod/.env.example prod/.env
+          printf 'YETI_AUTH_SECRET_KEY=%s\n' "$(openssl rand -hex 64)" >> prod/.env
       - name: Pull docker images from DockerHub
-        run: docker compose -f prod/docker-compose.yaml up -d
-      - name: Sleep for 1 minute
-        run: sleep 60
+        run: docker compose --env-file prod/.env -f prod/docker-compose.yaml up -d --wait --quiet-pull
       - name: Test access to the web UI
-        run: curl http://localhost:8000/api/v2/observables/
+        run: curl --fail --show-error --silent --retry 10 --retry-delay 6 --retry-connrefused http://localhost/ > /dev/null
+      - name: Tear down the test stack
+        if: always()
+        run: docker compose --env-file prod/.env -f prod/docker-compose.yaml down --volumes

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,15 +9,20 @@ on:
   schedule:
     - cron: "0 0 * * 6"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out yeti-docker
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Create CI environment from safe defaults
         run: |
-          cp prod/.env.example prod/.env
+          install -m 600 prod/.env.example prod/.env
           printf 'YETI_AUTH_SECRET_KEY=%s\n' "$(openssl rand -hex 64)" >> prod/.env
       - name: Pull docker images from DockerHub
         run: docker compose --env-file prod/.env -f prod/docker-compose.yaml up -d --wait --quiet-pull

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -26,8 +26,10 @@ jobs:
           printf 'YETI_AUTH_SECRET_KEY=%s\n' "$(openssl rand -hex 64)" >> prod/.env
       - name: Pull docker images from DockerHub
         run: docker compose --env-file prod/.env -f prod/docker-compose.yaml up -d --wait --quiet-pull
-      - name: Test access to the web UI
-        run: curl --fail --show-error --silent --retry 10 --retry-delay 6 --retry-connrefused http://localhost/ > /dev/null
+      - name: Test access to the web UI and proxied API
+        run: |
+          curl --fail --show-error --silent --retry 10 --retry-delay 6 --retry-connrefused http://localhost/ > /dev/null
+          curl --fail --show-error --silent --retry 10 --retry-delay 6 --retry-connrefused http://localhost/openapi.json > /dev/null
       - name: Tear down the test stack
         if: always()
         run: docker compose --env-file prod/.env -f prod/docker-compose.yaml down --volumes

--- a/.github/workflows/integration-e2e.yaml
+++ b/.github/workflows/integration-e2e.yaml
@@ -19,29 +19,31 @@ jobs:
     steps:
       - name: Check out yeti-docker
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          path: yeti-docker
 
       - name: Check out yeti
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: yeti-platform/yeti
           ref: ${{ inputs.yeti_ref }}
-          path: dev/yeti
+          path: yeti
 
       - name: Check out yeti-feeds-frontend
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: yeti-platform/yeti-feeds-frontend
           ref: ${{ inputs.frontend_ref }}
-          path: dev/yeti-feeds-frontend
+          path: yeti-feeds-frontend
 
       - name: Run the integration suite
         run: ./run.sh
-        working-directory: integration-tests
+        working-directory: yeti-docker/integration-tests
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
-          path: integration-tests/playwright/playwright-report/
+          path: yeti-docker/integration-tests/playwright/playwright-report/
           retention-days: 30

--- a/.github/workflows/integration-e2e.yaml
+++ b/.github/workflows/integration-e2e.yaml
@@ -12,6 +12,9 @@ on:
         required: false
         default: "main"
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -21,6 +24,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: yeti-docker
+          persist-credentials: false
 
       - name: Check out yeti
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -28,6 +32,7 @@ jobs:
           repository: yeti-platform/yeti
           ref: ${{ inputs.yeti_ref }}
           path: yeti
+          persist-credentials: false
 
       - name: Check out yeti-feeds-frontend
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -35,6 +40,7 @@ jobs:
           repository: yeti-platform/yeti-feeds-frontend
           ref: ${{ inputs.frontend_ref }}
           path: yeti-feeds-frontend
+          persist-credentials: false
 
       - name: Run the integration suite
         run: ./run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/dev/yeti
+/dev/yeti-agents
+/dev/yeti-feeds-frontend

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dev/yeti
 /dev/yeti-agents
 /dev/yeti-feeds-frontend
+/prod/.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Docker and integration agent instructions
+
+These instructions extend the workspace-level `../AGENTS.md` for the
+`yeti-docker` repository.
+
+## Project map
+
+- `dev`: local development Compose and bootstrap helpers.
+- `prod`: production image orchestration and environment template.
+- `integration-tests`: a disposable real backend/frontend/ArangoDB/Redis stack
+  with Playwright smoke tests.
+
+The canonical source layout is sibling repositories: `../yeti`,
+`../yeti-feeds-frontend`, and `../yeti-docker`. Compose paths resolve from this
+repository into those sibling checkouts. Do not add nested Git repositories or
+Git links under `dev`.
+
+## Commands
+
+- Render development configuration: `docker compose -f dev/docker-compose.yaml config`
+- Start development services: `docker compose -f dev/docker-compose.yaml up`
+- Render integration configuration: `docker compose -f integration-tests/docker-compose.yaml config`
+- Run the disposable real-stack suite: `(cd integration-tests && ./run.sh)`
+
+The integration runner builds the sibling source checkouts, creates synthetic
+credentials, runs Playwright, and removes its containers and volumes through an
+exit trap. Read `integration-tests/README.md` before changing selectors or test
+timing; it records known ArangoSearch and Vuetify behavior.
+
+## Orchestration boundaries
+
+- Never run `prod` Compose operations, publish images, remove persistent
+  volumes, or generate/rotate credentials without explicit authorization.
+- Keep real secrets in ignored `.env` files. Tracked examples must contain only
+  safe placeholders or development defaults.
+- Keep Compose build contexts relative and portable across macOS, Linux, and CI.
+- Pin coupled versions together, especially the Playwright package and Docker
+  image tag.
+- Validate Compose rendering after YAML changes. Run the full integration suite
+  when source paths, service health, authentication, or cross-stack behavior
+  changes and local resources permit it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Git links under `dev`.
 - Start development services: `docker compose -f dev/docker-compose.yaml up`
 - Render integration configuration: `docker compose -f integration-tests/docker-compose.yaml config`
 - Validate the integration port contract: `./tests/integration-port-contract.sh`
+- Validate production environment handling: `./tests/production-env-contract.sh`
 - Run the disposable real-stack suite: `(cd integration-tests && ./run.sh)`
 
 The integration runner builds the sibling source checkouts, creates synthetic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Docker and integration agent instructions
 
-These instructions extend the workspace-level `../AGENTS.md` for the
-`yeti-docker` repository.
+These instructions are self-contained for a standalone `yeti-docker` checkout.
+When the repository is part of the optional sibling Yeti workspace and
+`../AGENTS.md` exists, follow it as well for cross-repository coordination.
 
 ## Project map
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Git links under `dev`.
 - Render development configuration: `docker compose -f dev/docker-compose.yaml config`
 - Start development services: `docker compose -f dev/docker-compose.yaml up`
 - Render integration configuration: `docker compose -f integration-tests/docker-compose.yaml config`
+- Validate the integration port contract: `./tests/integration-port-contract.sh`
 - Run the disposable real-stack suite: `(cd integration-tests && ./run.sh)`
 
 The integration runner builds the sibling source checkouts, creates synthetic

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,6 +1,10 @@
 # Yeti Dev docker images
 
-Clone this repo, then run `./init.sh`. You might need some additional steps:
+Clone this repository next to `yeti` and `yeti-feeds-frontend`, then run
+`./init.sh`. The script clones either missing sibling and starts the core
+development stack. AI services are optional; if a sibling `yeti-agents`
+checkout is configured, start them with
+`YETI_AGENTS_ENABLED=True docker compose --profile agents up`.
 
 ## `api` container
 
@@ -16,14 +20,14 @@ Then once you get a root shell in the docker container (prompt like
 `root@dcaa45f226bc:/app#`)
 
 ```bash
-poetry run uvicorn core.web.webapp:app --reload --host 0.0.0.0
+uv run uvicorn core.web.webapp:app --reload --host 0.0.0.0
 ```
 
 NOTE: You can, of course, run all these commands directly into the `docker exec`
 command:
 
 ```bash
-docker compose exec api poetry run uvicorn core.web.webapp:app --reload --host 0.0.0.0
+docker compose exec api uv run uvicorn core.web.webapp:app --reload --host 0.0.0.0
 ```
 
 This will work for all the other commands in this doc.
@@ -35,7 +39,7 @@ need to run the following command from the `api` container (prompt like
 `root@772ea966d9a8:/app#`)
 
 ```bash
-poetry run celery -A core.taskscheduler worker --loglevel=INFO
+uv run celery -A core.taskscheduler worker --loglevel=INFO
 ```
 
 ### Events tasks
@@ -45,7 +49,7 @@ consumers. To do so, you need to run the following command from the `api`
 container (prompt like `root@772ea966d9a8:/app#`).
 
 ```bash
-poetry run python -m core.events.consumers events
+uv run python -m core.events.consumers events
 ```
 
 You can adjust concurrency with `--concurrency <number_of_worker>` and enable

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -16,8 +16,9 @@ services:
       - YETI_AUTH_BROWSER_TOKEN_EXPIRE_MINUTES=43200
       - YETI_AUTH_ENABLED=False
       - YETI_SYSTEM_PLUGINS_PATH=./plugins
+      - YETI_AGENTS_ENABLED=${YETI_AGENTS_ENABLED:-False}
     build:
-      context: ./yeti/
+      context: ../../yeti/
       dockerfile: ./extras/docker/dev/Dockerfile
     image: yeti
     entrypoint: ["/bin/bash", "/docker-entrypoint.sh"]
@@ -31,20 +32,20 @@ services:
         condition: service_healthy
     volumes:
       - /tmp/docker-yeti-exports:/opt/yeti/exports
-      - ./yeti/:/app/
+      - ../../yeti/:/app/
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
   frontend:
     build:
-      context: ./yeti-feeds-frontend/
+      context: ../../yeti-feeds-frontend/
       dockerfile: ./docker/dev/Dockerfile
     image: yeti-feeds-frontend
     ports:
       - 127.0.0.1:8080:8080
       - 127.0.0.1:3000:3000
     volumes:
-      - ./yeti-feeds-frontend/:/app
+      - ../../yeti-feeds-frontend/:/app
     entrypoint:
       - /docker-entrypoint.sh
     command:
@@ -80,20 +81,22 @@ services:
       - /tmp/bloomfilters:/bloomfilters:ro
 
   agents:
+    profiles: ["agents"]
     container_name: agents
     build:
-      context: ./yeti-agents/
+      context: ../../yeti-agents/
     image: yetiplatform/yeti-agents:dev
     ports:
       - 127.0.0.1:8888:8888
     env_file:
-      - ./yeti-agents/.env
+      - ../../yeti-agents/.env
     volumes:
-      - ./yeti-agents/:/app
+      - ../../yeti-agents/:/app
     entrypoint: [ "/bin/bash", "/app/entrypoint.sh" ]
     command: [ "manual" ]
 
   ollama:
+    profiles: ["agents"]
     container_name: ollama
     image: ollama/ollama:latest
     ports:

--- a/dev/init.ps1
+++ b/dev/init.ps1
@@ -1,12 +1,31 @@
-# Cloner le répertoire yeti
-git clone https://github.com/yeti-platform/yeti.git
-# Copier le fichier de configuration
-Copy-Item -Path "yeti/yeti.conf.sample" -Destination "yeti/yeti.conf"
+$ErrorActionPreference = "Stop"
 
-# Cloner le répertoire yeti-feeds-frontend
-git clone https://github.com/yeti-platform/yeti-feeds-frontend.git
+$WorkspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
 
+function Clone-IfMissing([string]$Repository) {
+    $Target = Join-Path $WorkspaceRoot $Repository
+    $GitMetadata = Join-Path $Target ".git"
+    if (Test-Path $GitMetadata) {
+        Write-Host "present: $Repository"
+    } elseif (Test-Path $Target) {
+        throw "Refusing to overwrite non-repository path: $Target"
+    } else {
+        git clone "https://github.com/yeti-platform/$Repository.git" $Target
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to clone $Repository"
+        }
+    }
+}
 
+Clone-IfMissing "yeti"
+Clone-IfMissing "yeti-feeds-frontend"
 
-# Construire et démarrer les conteneurs Docker
-docker compose up
+$BackendConfig = Join-Path $WorkspaceRoot "yeti/yeti.conf"
+if (-not (Test-Path $BackendConfig)) {
+    Copy-Item (Join-Path $WorkspaceRoot "yeti/yeti.conf.sample") $BackendConfig
+}
+
+docker compose -f (Join-Path $PSScriptRoot "docker-compose.yaml") up
+if ($LASTEXITCODE -ne 0) {
+    throw "Docker Compose failed"
+}

--- a/dev/init.sh
+++ b/dev/init.sh
@@ -1,10 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-git clone https://github.com/yeti-platform/yeti.git
-cp yeti/yeti.conf.sample yeti/yeti.conf
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_root="$(cd "$script_dir/../.." && pwd)"
 
-git clone https://github.com/yeti-platform/yeti-feeds-frontend.git
+clone_if_missing() {
+  local repository=$1
+  local target="$workspace_root/$repository"
+  if [[ -d "$target/.git" || -f "$target/.git" ]]; then
+    printf 'present: %s\n' "$repository"
+  elif [[ -e "$target" ]]; then
+    printf 'refusing to overwrite non-repository path: %s\n' "$target" >&2
+    exit 1
+  else
+    git clone "https://github.com/yeti-platform/$repository.git" "$target"
+  fi
+}
+
+clone_if_missing yeti
+clone_if_missing yeti-feeds-frontend
+
+if [[ ! -f "$workspace_root/yeti/yeti.conf" ]]; then
+  cp "$workspace_root/yeti/yeti.conf.sample" "$workspace_root/yeti/yeti.conf"
+fi
 
 mkdir -p /tmp/bloomfilters
-
-docker compose up
+docker compose -f "$script_dir/docker-compose.yaml" up

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -118,14 +118,13 @@ about to tag.
   the option by role) instead -- see `tests/indicator-lifecycle.spec.ts`.
 - **A search result's `role="option"` can be the whole `v-list-item`, not
   just the item's own name text.** `EntitySelector.vue` (used by the
-  "link objects" dialog) renders each result as a name button *and* a
-  separate "details" button inside one list item that itself carries
-  `role="option"` -- Playwright's accessible-name computation for that
-  option doesn't reliably match on just the visible name (it can silently
-  resolve to zero elements, hanging or clicking nothing). Match by raw text
-  via `page.locator('[role="option"]').filter({ hasText: name })` instead,
-  and click the inner name button specifically, not the option/list-item
-  as a whole -- see `tests/entity-indicator-link.spec.ts`.
+  "link objects" dialog) binds the Vuetify selection props to that list item
+  and renders only a separate "details" button inside it. Playwright's
+  accessible-name computation for the option can include the details link,
+  so match by raw text via
+  `page.locator('[role="option"]').filter({ hasText: name })` and click the
+  option itself. The nested details button deliberately stops propagation and
+  does not select the result -- see `tests/entity-indicator-link.spec.ts`.
 - **Deep-linking to a details-page tab via a URL `#hash` on a fresh page
   load can land on the wrong tab.** The hash-driven tab-selection watcher
   can race Vue Router's own initial hash resolution on a cold `page.goto`

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -90,6 +90,11 @@ about to tag.
   past what's reasonable to poll for (observed >15s vs ~1-2s for an
   untagged object) -- verify deletion via a direct API call instead of the
   search view in that case (see the same spec's final step).
+- **A successful observable search assertion does not make its row stable.**
+  A pending refresh can replace the table immediately afterward and detach a
+  link before Playwright clicks it. Verify the named link and its exact details
+  `href` inside the retry, then navigate to that verified path before continuing
+  with user-level edit/delete actions (see `tests/observable-lifecycle.spec.ts`).
 - **`getByRole("dialog")`, not `.v-overlay--active`**, to target a dialog.
   Against a real backend, save/create snackbars are genuinely visible (not
   fast-forwarded like a mock) and also carry the `v-overlay--active` class,
@@ -100,15 +105,14 @@ about to tag.
   bare `tbody tr` locator picks up rows from every hidden tab too -- scope
   to `tbody tr:visible` (see `tests/entity-lifecycle.spec.ts` /
   `tests/indicator-lifecycle.spec.ts`).
-- **Retrying an entities/indicators search only works if the search box's
-  value actually changes.** Unlike Observables' own search box (which calls
-  `loadObjects()` directly on Enter), EntitySearch/IndicatorSearch only
-  re-query when the underlying Vue ref's *value* changes on `keyup.enter`
-  -- Vue refs are no-ops on an unchanged value, so refilling the same
-  search text on every retry iteration silently never re-fires the
-  request, and the test will hang on whatever the first (possibly stale)
-  response was. `clear()` then `fill()` each retry to force a real change
-  both ways (see the same two specs' search steps).
+- **Retrying entity/indicator searches only works if the search value actually
+  changes.** Unlike Observables' search box (which calls `loadObjects()` on
+  Enter), the entity/indicator pages and `EntitySelector` autocomplete depend
+  on a changed Vue ref before issuing another request. Vue drops a same-value
+  assignment as a no-op, so refilling identical text can leave the first stale
+  result in place indefinitely. `clear()` then `fill()` on every retry (and
+  press Enter for the page-level search boxes) to force a new request; see the
+  entity, indicator, and entity-indicator-link specs.
 - **The v-select used for fields like "Diamond model" (indicators) doesn't
   reliably `.click()`.** (The original cause -- the parent "New X"
   type-picker menu never closing once a type's dialog opened -- was fixed

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -2,7 +2,7 @@
 
 Runs Playwright against a real Yeti stack -- real ArangoDB, real API, real
 frontend, no mocked network requests -- unlike the frontend's own e2e suite
-(`dev/yeti-feeds-frontend/tests/e2e`), which deliberately mocks every
+(`../../yeti-feeds-frontend/tests/e2e`), which deliberately mocks every
 `/api/v2/**` call and never starts a backend at all. This suite exists to
 catch the class of bug that suite structurally can't: real backend bugs,
 real auth flows, real timing/consistency issues across the stack.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -20,8 +20,8 @@ mocked suite is for.
 ./run.sh
 ```
 
-This builds `dev/yeti` and `dev/yeti-feeds-frontend` (as checked out
-locally -- whatever you have checked out is what gets tested), starts a
+This builds the sibling `yeti` and `yeti-feeds-frontend` repositories (whatever
+you have checked out locally is what gets tested), starts a
 fresh stack, seeds a test admin user, runs the suite, and tears everything
 down again regardless of outcome. Override the seeded credentials or target
 URL via env vars if needed:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -23,8 +23,15 @@ mocked suite is for.
 This builds the sibling `yeti` and `yeti-feeds-frontend` repositories (whatever
 you have checked out locally is what gets tested), starts a
 fresh stack, seeds a test admin user, runs the suite, and tears everything
-down again regardless of outcome. Override the seeded credentials or target
-URL via env vars if needed:
+down again regardless of outcome. The frontend binds to host port `18080` by
+default. Override the port when it is already in use; `run.sh` derives its
+default `BASE_URL` from the selected port:
+
+```sh
+INTEGRATION_FRONTEND_PORT=18081 ./run.sh
+```
+
+You can also override the seeded credentials or provide an explicit target URL:
 
 ```sh
 TEST_USERNAME=myuser TEST_PASSWORD='...' BASE_URL=http://127.0.0.1:18080 ./run.sh

--- a/integration-tests/docker-compose.yaml
+++ b/integration-tests/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
 
   api:
     build:
-      context: ../dev/yeti
+      context: ../../yeti
       dockerfile: ./extras/docker/Dockerfile
     command: ["webserver-prod"]
     environment:
@@ -45,7 +45,7 @@ services:
 
   frontend:
     build:
-      context: ../dev/yeti-feeds-frontend
+      context: ../../yeti-feeds-frontend
       dockerfile: ./docker/prod/Dockerfile
     volumes:
       - ./frontend-nginx.conf:/etc/nginx/conf.d/default.conf

--- a/integration-tests/docker-compose.yaml
+++ b/integration-tests/docker-compose.yaml
@@ -53,4 +53,4 @@ services:
       api:
         condition: service_started
     ports:
-      - 127.0.0.1:18080:80
+      - 127.0.0.1:${INTEGRATION_FRONTEND_PORT:-18080}:80

--- a/integration-tests/playwright/tests/entity-indicator-link.spec.ts
+++ b/integration-tests/playwright/tests/entity-indicator-link.spec.ts
@@ -64,9 +64,11 @@ test("link an entity and an indicator, and confirm they appear in each other's n
   //
   // The autocomplete's own /entities, /indicators, /dfiq searches go
   // through the same eventually-consistent ArangoSearch views as
-  // everywhere else -- retry until the freshly-created indicator actually
-  // shows up and the click sticks (Save reports the target as picked).
+  // everywhere else. Clear before every fill so Vue observes a real search
+  // value change on each retry; filling the same value again is a no-op and
+  // would leave the first stale response in place indefinitely.
   await expect(async () => {
+    await linkTargetSearch.clear();
     await linkTargetSearch.fill(indicatorName);
     const option = page.locator('[role="option"]').filter({ hasText: indicatorName });
     await expect(option).toBeVisible();

--- a/integration-tests/playwright/tests/entity-indicator-link.spec.ts
+++ b/integration-tests/playwright/tests/entity-indicator-link.spec.ts
@@ -56,13 +56,11 @@ test("link an entity and an indicator, and confirm they appear in each other's n
   await expect(linkDialog.getByText(`New link for ${entityName}`)).toBeVisible();
   const linkTargetSearch = linkDialog.getByRole("combobox", { name: "Search for entities or indicators" });
   const saveLinkButton = linkDialog.getByRole("button", { name: "Save" });
-  // Each search result is a v-list-item carrying role="option" itself, but
-  // wrapping *two* buttons (the item's own name, and a separate "details"
-  // link) -- Playwright's accessible-name computation for that option
-  // doesn't reliably match on just the item's name text (it can silently
-  // resolve to zero elements). Match by raw text via the [role="option"]
-  // attribute selector instead, and click the inner name button
-  // specifically, not the option/list-item wrapper as a whole.
+  // Each search result is a v-list-item carrying both role="option" and the
+  // Vuetify selection props. Its only nested button is the separate "details"
+  // link, which deliberately stops click propagation. Playwright's accessible
+  // name for the option can include that link, so match by raw text via the
+  // [role="option"] selector and click the option itself to select it.
   //
   // The autocomplete's own /entities, /indicators, /dfiq searches go
   // through the same eventually-consistent ArangoSearch views as
@@ -72,7 +70,7 @@ test("link an entity and an indicator, and confirm they appear in each other's n
     await linkTargetSearch.fill(indicatorName);
     const option = page.locator('[role="option"]').filter({ hasText: indicatorName });
     await expect(option).toBeVisible();
-    await option.getByRole("button").first().click();
+    await option.click();
     await expect(saveLinkButton).toBeEnabled();
   }).toPass({ timeout: 20_000 });
 

--- a/integration-tests/playwright/tests/observable-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/observable-lifecycle.spec.ts
@@ -30,6 +30,7 @@ test("create, search, tag, and delete an observable", async ({ page }) => {
   await expect(page).toHaveURL(/\/observables\/[\w-]+$/);
   await expect(page.locator(".observable-value")).toHaveText(hostname);
   const observableId = new URL(page.url()).pathname.split("/").pop();
+  const observableDetailsPath = `/observables/${observableId}`;
 
   // --- Tag ---
   const tagBox = page.locator(".v-combobox input").first();
@@ -44,16 +45,21 @@ test("create, search, tag, and delete an observable", async ({ page }) => {
   // itself, not just the assertion, until the view has caught up.
   await page.goto("/observables");
   const searchInput = page.getByRole("textbox", { name: /Search observables/ });
+  const matchingObservableLink = page.getByRole("link", { name: hostname, exact: true });
   await expect(async () => {
     await searchInput.fill(hostname);
     await searchInput.press("Enter");
     await expect(page.locator("tbody tr")).toHaveCount(1);
     await expect(page.locator("tbody tr").first()).toContainText("integration-test-tag");
+    await expect(matchingObservableLink).toBeVisible();
+    await expect(matchingObservableLink).toHaveAttribute("href", observableDetailsPath);
   }).toPass({ timeout: 10_000 });
-  await expect(page.locator("tbody tr").first()).toContainText(hostname);
 
   // --- Delete ---
-  await page.locator("tbody tr").first().getByRole("link", { name: hostname }).click();
+  // A pending search refresh can replace the verified row between the retry
+  // completing and a click, detaching the link. Navigate to the exact href
+  // verified above, then keep the destructive action itself in the UI.
+  await page.goto(observableDetailsPath);
   await expect(page).toHaveURL(/\/observables\/[\w-]+$/);
   await page.getByRole("button", { name: "Edit" }).click();
 

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -8,7 +8,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 export TEST_USERNAME="${TEST_USERNAME:-integration-test}"
 export TEST_PASSWORD="${TEST_PASSWORD:-Integration-Test-Password-1!}"
-export BASE_URL="${BASE_URL:-http://127.0.0.1:18080}"
+export INTEGRATION_FRONTEND_PORT="${INTEGRATION_FRONTEND_PORT:-18080}"
+export BASE_URL="${BASE_URL:-http://127.0.0.1:${INTEGRATION_FRONTEND_PORT}}"
 
 cleanup() {
   echo "--- Tearing down integration stack ---"

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -21,7 +21,8 @@ echo "--- Building and starting the integration stack ---"
 docker compose up -d --build --wait
 
 echo "--- Seeding test user ($TEST_USERNAME) ---"
-docker compose run --rm api create-user "$TEST_USERNAME" "$TEST_PASSWORD" --admin
+docker compose run --rm api create-user "$TEST_USERNAME" "$TEST_PASSWORD" --admin > /dev/null
+echo "--- Test user seeded without logging credentials ---"
 
 echo "--- Running Playwright integration suite ---"
 # Run inside the official Playwright image rather than on the host: it ships

--- a/prod/.env.example
+++ b/prod/.env.example
@@ -11,7 +11,7 @@ YETI_ARANGODB_DATABASE=yeti
 YETI_ARANGODB_USERNAME=root
 YETI_ARANGODB_PASSWORD=
 
-# Empty secret will generate an error upon startup
+# `prod/init.sh` adds a generated YETI_AUTH_SECRET_KEY to the local `.env`.
 YETI_AUTH_ALGORITHM=HS256
 YETI_AUTH_ACCESS_TOKEN_EXPIRE_MINUTES=30
 

--- a/prod/README.md
+++ b/prod/README.md
@@ -1,3 +1,6 @@
 # Installation
 
 Follow the canonical instructions: https://yeti-platform.io/docs/getting-started/
+
+`init.sh` creates an ignored `.env` from `.env.example` when needed and adds a
+generated authentication secret. Never commit the resulting `.env`.

--- a/prod/init.sh
+++ b/prod/init.sh
@@ -5,8 +5,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$script_dir"
 
 if [[ ! -f .env ]]; then
-  cp .env.example .env
+  (umask 077 && cp .env.example .env)
 fi
+chmod 600 .env
 
 if ! grep -q '^YETI_AUTH_SECRET_KEY=' .env; then
   secret_key="$(openssl rand -hex 64)"

--- a/prod/init.sh
+++ b/prod/init.sh
@@ -1,6 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-SECRET_KEY=$(openssl rand -hex 64)
-echo YETI_AUTH_SECRET_KEY=$SECRET_KEY >> .env
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+if [[ ! -f .env ]]; then
+  cp .env.example .env
+fi
+
+if ! grep -q '^YETI_AUTH_SECRET_KEY=' .env; then
+  secret_key="$(openssl rand -hex 64)"
+  printf 'YETI_AUTH_SECRET_KEY=%s\n' "$secret_key" >> .env
+fi
+
 mkdir -p /opt/yeti/bloomfilters
 docker compose up -d --wait --quiet-pull

--- a/tests/fixtures/docker
+++ b/tests/fixtures/docker
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DOCKER_TEST_LOG:?DOCKER_TEST_LOG must identify the invocation log}"
+
+{
+  printf 'BASE_URL=%s\n' "${BASE_URL-}"
+  printf 'INTEGRATION_FRONTEND_PORT=%s\n' "${INTEGRATION_FRONTEND_PORT-}"
+  printf 'DOCKER_ARGS='
+  printf ' %q' "$@"
+  printf '\n'
+} >> "$DOCKER_TEST_LOG"

--- a/tests/fixtures/docker
+++ b/tests/fixtures/docker
@@ -10,3 +10,7 @@ set -euo pipefail
   printf ' %q' "$@"
   printf '\n'
 } >> "$DOCKER_TEST_LOG"
+
+if [[ "$*" == compose\ run\ --rm\ api\ create-user* ]]; then
+  printf 'synthetic-secret-api-token\n'
+fi

--- a/tests/fixtures/mkdir
+++ b/tests/fixtures/mkdir
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Production bootstrap creates a host directory after preparing the environment.
+# The contract test only exercises environment handling, so keep that side effect local.
+exit 0

--- a/tests/fixtures/openssl
+++ b/tests/fixtures/openssl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" != "rand -hex 64" ]]; then
+  printf 'unexpected openssl invocation: %s\n' "$*" >&2
+  exit 1
+fi
+
+printf '%0128d\n' 0

--- a/tests/integration-port-contract.sh
+++ b/tests/integration-port-contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/.." && pwd)"
+compose_file="$repository_root/integration-tests/docker-compose.yaml"
+run_script="$repository_root/integration-tests/run.sh"
+fixture_dir="$script_dir/fixtures"
+
+assert_rendered_port() {
+  local rendered_config=$1
+  local expected_port=$2
+
+  if ! grep -Eq "\"published\"[[:space:]]*:[[:space:]]*\"$expected_port\"" <<< "$rendered_config"; then
+    printf 'expected rendered frontend host port %s\n' "$expected_port" >&2
+    exit 1
+  fi
+}
+
+default_config="$(env -u INTEGRATION_FRONTEND_PORT docker compose -f "$compose_file" config --format json)"
+override_config="$(INTEGRATION_FRONTEND_PORT=18081 docker compose -f "$compose_file" config --format json)"
+assert_rendered_port "$default_config" 18080
+assert_rendered_port "$override_config" 18081
+
+test_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/yeti-integration-port.XXXXXX")"
+trap 'rm -r "$test_tmp_dir"' EXIT
+docker_test_log="$test_tmp_dir/docker.log"
+
+assert_harness_environment() {
+  local expected_port=$1
+  local expected_base_url=$2
+  shift 2
+
+  : > "$docker_test_log"
+  env -u BASE_URL -u INTEGRATION_FRONTEND_PORT \
+    PATH="$fixture_dir:$PATH" \
+    DOCKER_TEST_LOG="$docker_test_log" \
+    "$@" \
+    "$run_script" > /dev/null
+
+  grep -Fxq "INTEGRATION_FRONTEND_PORT=$expected_port" "$docker_test_log"
+  grep -Fxq "BASE_URL=$expected_base_url" "$docker_test_log"
+}
+
+assert_harness_environment 18080 http://127.0.0.1:18080
+assert_harness_environment 18081 http://127.0.0.1:18081 INTEGRATION_FRONTEND_PORT=18081
+
+printf 'integration frontend port contract: ok\n'

--- a/tests/integration-port-contract.sh
+++ b/tests/integration-port-contract.sh
@@ -25,6 +25,7 @@ assert_rendered_port "$override_config" 18081
 test_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/yeti-integration-port.XXXXXX")"
 trap 'rm -r "$test_tmp_dir"' EXIT
 docker_test_log="$test_tmp_dir/docker.log"
+harness_output="$test_tmp_dir/harness.out"
 
 assert_harness_environment() {
   local expected_port=$1
@@ -36,10 +37,15 @@ assert_harness_environment() {
     PATH="$fixture_dir:$PATH" \
     DOCKER_TEST_LOG="$docker_test_log" \
     "$@" \
-    "$run_script" > /dev/null
+    "$run_script" > "$harness_output"
 
   grep -Fxq "INTEGRATION_FRONTEND_PORT=$expected_port" "$docker_test_log"
   grep -Fxq "BASE_URL=$expected_base_url" "$docker_test_log"
+  if grep -Fq 'synthetic-secret-api-token' "$harness_output"; then
+    printf 'create-user output leaked into integration logs\n' >&2
+    exit 1
+  fi
+  grep -Fxq -- '--- Test user seeded without logging credentials ---' "$harness_output"
 }
 
 assert_harness_environment 18080 http://127.0.0.1:18080

--- a/tests/production-env-contract.sh
+++ b/tests/production-env-contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/.." && pwd)"
+fixture_dir="$script_dir/fixtures"
+test_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/yeti-production-env.XXXXXX")"
+trap 'rm -r "$test_tmp_dir"' EXIT
+
+cp "$repository_root/prod/init.sh" "$repository_root/prod/.env.example" "$test_tmp_dir/"
+docker_test_log="$test_tmp_dir/docker.log"
+
+run_bootstrap() {
+  (
+    cd "$test_tmp_dir"
+    umask 022
+    PATH="$fixture_dir:$PATH" \
+      DOCKER_TEST_LOG="$docker_test_log" \
+      ./init.sh > /dev/null
+  )
+}
+
+environment_mode() {
+  if stat -f '%Lp' "$test_tmp_dir/.env" > /dev/null 2>&1; then
+    stat -f '%Lp' "$test_tmp_dir/.env"
+  else
+    stat -c '%a' "$test_tmp_dir/.env"
+  fi
+}
+
+run_bootstrap
+if [[ "$(environment_mode)" != 600 ]]; then
+  printf 'expected a newly generated .env to use mode 600\n' >&2
+  exit 1
+fi
+
+chmod 0644 "$test_tmp_dir/.env"
+run_bootstrap
+if [[ "$(environment_mode)" != 600 ]]; then
+  printf 'expected an existing .env to be restricted to mode 600\n' >&2
+  exit 1
+fi
+
+if [[ "$(grep -c '^YETI_AUTH_SECRET_KEY=' "$test_tmp_dir/.env")" != 1 ]]; then
+  printf 'expected exactly one generated authentication secret\n' >&2
+  exit 1
+fi
+
+printf 'production environment contract: ok\n'


### PR DESCRIPTION
## Summary

- make development and real-stack Compose builds consume the canonical sibling `yeti` and `yeti-feeds-frontend` repositories
- keep optional agent services profile-gated and document agent-safe orchestration boundaries
- replace the tracked production runtime environment with a safe template, owner-only local files, and idempotent secret generation
- restrict workflows to read-only contents access and prevent checkout credentials from entering Docker build contexts
- parameterize the integration frontend port while retaining 18080 by default
- suppress token-bearing create-user output while preserving errors and exit status
- stabilize current Vuetify selection, Vue search retry, ArangoSearch, and refreshed-row behavior
- add bounded production smoke CI plus executable shell and environment contracts

## Validation

- integration-port and production-environment contract tests passed
- Bash syntax and ShellCheck passed for development, production, integration, test, and fixture scripts
- development, integration, and production Compose models rendered successfully
- Playwright TypeScript check passed; all 6 real-stack tests passed on `INTEGRATION_FRONTEND_PORT=18081`
- branch whitespace and targeted secret-pattern checks passed
- independent adversarial review found no remaining code blocker

## External limitation

GitHub reports the `Docker prod test` workflow (ID 77289175) as `disabled_inactivity`. PR 36 therefore has no automated checks until a repository owner explicitly re-enables it; the full contract and real-stack matrix above was run locally.

PowerShell syntax execution was unavailable on this host. The optional agents profile could not be fully rendered because no sibling `yeti-agents/.env` checkout is present; the core development model and profile declaration were validated.
