### PR TITLE
test: cover graph investigation real stack

### DIFF
--- a/integration-tests/playwright/tests/graph-workspace.spec.ts
+++ b/integration-tests/playwright/tests/graph-workspace.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+interface CreatedObject {
+  id: string;
+  type: string;
+}
+
+test("investigate directed evidence and add a second anchor without mutating the graph", async ({ page }) => {
+  const suffix = Date.now();
+  const firstName = `integration-graph-malware-a-${suffix}`;
+  const secondName = `integration-graph-malware-b-${suffix}`;
+  const hostname = `integration-graph-${suffix}.example.com`;
+  const createdPaths: string[] = [];
+
+  await login(page);
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  expect(tokenResponse.ok()).toBeTruthy();
+  const { access_token: accessToken } = await tokenResponse.json();
+  const headers = { Authorization: `Bearer ${accessToken}` };
+
+  try {
+    const createEntity = async (name: string) => {
+      const response = await page.request.post("/api/v2/entities/", {
+        headers,
+        data: { entity: { name, type: "malware" } }
+      });
+      expect(response.ok()).toBeTruthy();
+      return (await response.json()) as CreatedObject;
+    };
+    const first = await createEntity(firstName);
+    const second = await createEntity(secondName);
+    const observableResponse = await page.request.post("/api/v2/observables/extended", {
+      headers,
+      data: { observable: { value: hostname, type: "hostname" } }
+    });
+    expect(observableResponse.ok()).toBeTruthy();
+    const observable = (await observableResponse.json()) as CreatedObject;
+    createdPaths.push(`/api/v2/entities/${first.id}`, `/api/v2/entities/${second.id}`, `/api/v2/observables/${observable.id}`);
+
+    for (const [source, description] of [
+      [first, "First synthetic directed relationship"],
+      [second, "Second synthetic directed relationship"]
+    ] as const) {
+      const response = await page.request.post("/api/v2/graph/add", {
+        headers,
+        data: {
+          source: `${source.type}/${source.id}`,
+          target: `${observable.type}/${observable.id}`,
+          link_type: "communicates-with",
+          description
+        }
+      });
+      expect(response.ok()).toBeTruthy();
+    }
+
+    const mutationRequests: string[] = [];
+    page.on("request", request => {
+      const path = new URL(request.url()).pathname;
+      if (!path.startsWith("/api/v2/graph/")) return;
+      if (path === "/api/v2/graph/explore" || path === "/api/v2/graph/search") return;
+      mutationRequests.push(`${request.method()} ${path}`);
+    });
+
+    await page.goto(`/entities/${first.id}`);
+    await page.getByRole("link", { name: "Explore in graph" }).click();
+
+    await expect(page).toHaveURL(/\/graph#/);
+    await expect(page.getByRole("heading", { name: "Evidence" })).toBeVisible();
+    await expect(page.getByText("2 objects")).toBeVisible();
+    await expect(page.getByText("1 relationships")).toBeVisible();
+    await expect(page.getByRole("cell", { name: `entities/${first.id} → observables/${observable.id}` })).toBeVisible();
+    await expect(page.getByText("First synthetic directed relationship")).toBeVisible();
+
+    const objectIds = page.getByLabel("Yeti object IDs");
+    await expect(objectIds).toHaveValue(`entities/${first.id}`);
+    await objectIds.fill(`entities/${first.id}\nentities/${second.id}`);
+    await page.getByRole("button", { name: "Explore objects" }).click();
+
+    await expect(page.getByText("3 objects")).toBeVisible();
+    await expect(page.getByText("2 relationships")).toBeVisible();
+    await expect(page.getByRole("button", { name: firstName, exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: secondName, exact: true })).toBeVisible();
+    await expect(page.getByText("Second synthetic directed relationship")).toBeVisible();
+    expect(mutationRequests).toEqual([]);
+  } finally {
+    for (const path of createdPaths) {
+      await page.request.delete(path, { headers });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- add a disposable Playwright path for the dedicated graph workspace
- create synthetic objects and directed relationships through the real API
- launch from Explore in graph, verify exact evidence, add a second anchor, and assert no graph mutation call
- delete synthetic objects and rely on the existing safe harness for complete stack cleanup

## Dependencies

Stacked on #36 and requires yeti-platform/yeti#1338 plus yeti-platform/yeti-feeds-frontend#303. Safe merge order is backend, frontend, then this coverage PR.

## Validation

- TypeScript/Playwright discovery and Compose rendering passed
- INTEGRATION_FRONTEND_PORT=18081 make test-integration: 10 passed
- teardown removed the disposable containers, network, and volumes

## Security and data handling

The scenario uses generated synthetic values only, obtains credentials through the existing test harness, checks that investigation sends no POST, PATCH, PUT, or DELETE graph mutation request, and cleans the created objects in a finally block.

## Rollback

Revert this test-only commit. Production Compose behavior and persistence are unchanged.