### PR TITLE
Add edit-flow and DFIQ facet/approaches integration specs

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -165,6 +165,25 @@ about to tag.
   help (the underlying fetch never re-runs). Poll the search API directly
   before opening the dialog instead of retrying inside it, see
   `tests/dfiq-question-multiple-parents.spec.ts`.
+- **A bare `.click()` on a "Delete" confirm button doesn't wait for the
+  DELETE request it triggers**, only for the click event to dispatch. An
+  immediate follow-up API check (the pattern every lifecycle spec uses to
+  confirm deletion) can race ahead of that in-flight request and see a
+  stale 200 instead of 404 -- rare on a quiet run, but consistently
+  reproducible once several other specs have already run in the same
+  worker and pushed request latency up. `page.waitForResponse(...)`
+  around the click, same as the tag-step pattern already used elsewhere,
+  fixes it -- see any of the `*-lifecycle.spec.ts` files or
+  `tests/dfiq-scenario.spec.ts`.
+- **The same eventual-consistency gotcha applies to a spec's own cleanup
+  step, not just its assertions.** A cleanup block that searches for an
+  object it just created (rather than using an ID it already has) can hit
+  the same ArangoSearch-view lag and silently find zero matches -- the
+  loop over an empty array just does nothing, so the object leaks instead
+  of the test failing loudly. Retry the search until it returns a match
+  (`expect(...).toPass(...)`, same as the pre-flight check above) rather
+  than searching once -- see `tests/dfiq-facet.spec.ts` and
+  `tests/dfiq-scenario-inline-question.spec.ts`.
 
 ## Adding a spec
 

--- a/integration-tests/playwright/tests/dfiq-facet.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-facet.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Facet is a full DFIQ type (scenario -> facet -> question) that no other
+ * spec ever creates. Facets always require a parent scenario (the create
+ * template embeds a non-empty parent_ids), so -- like
+ * dfiq-scenario-inline-question.spec.ts's question -- this creates one via
+ * the DFIQ tree's inline "new facet" button rather than the top-level "New
+ * DFIQ object" flow, which has no parent to supply.
+ */
+test("create a scenario, then add a facet inline from its DFIQ tree", async ({ page }) => {
+  const scenarioName = `integration-test-scenario-${Date.now()}`;
+  const facetName = `integration-test-facet-${Date.now()}`;
+
+  await login(page);
+
+  // --- Create the scenario ---
+  await page.goto("/dfiq");
+  await page.getByRole("button", { name: "New DFIQ object" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Scenario" }).first().click();
+
+  const newScenarioDialog = page.getByRole("dialog");
+  await expect(newScenarioDialog.getByText("Creating DFIQ scenario")).toBeVisible();
+  await newScenarioDialog.getByLabel("Name").fill(scenarioName);
+  await expect(newScenarioDialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await newScenarioDialog.getByRole("button", { name: "Save" }).click();
+  await expect(page).toHaveURL(/\/dfiq\/[\w-]+$/);
+  const scenarioId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Add a facet inline, from the DFIQ tree tab ---
+  await page.getByRole("tab", { name: /DFIQ tree/ }).click();
+  const scenarioRow = page.locator("li").filter({ hasText: scenarioName }).first();
+  await scenarioRow.hover();
+  await scenarioRow.getByRole("button", { name: "new facet" }).click();
+
+  const newFacetDialog = page.getByRole("dialog").last();
+  await expect(newFacetDialog.getByText("Creating DFIQ facet")).toBeVisible();
+  await expect(newFacetDialog.getByText(`pre-populated from scenario "${scenarioName}"`)).toBeVisible();
+  await newFacetDialog.getByLabel("Name").fill(facetName);
+  await expect(newFacetDialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await newFacetDialog.getByRole("button", { name: "Save" }).click();
+
+  // No redirect for the inline-create path -- the dialog just closes and the
+  // tree refetches via the DFIQupdated event bus (see
+  // dfiq-scenario-inline-question.spec.ts for the same pattern).
+  await expect(newFacetDialog).toBeHidden();
+  const facetRow = page.locator("li").filter({ hasText: facetName }).first();
+  await expect(facetRow).toBeVisible();
+
+  // A facet's own tree row should offer "new question" (it can parent
+  // questions) but not "new facet" (facets can't parent facets) --
+  // confirms DFIQHierarchy's per-type children are wired correctly, not
+  // just that some node got created somewhere in the tree.
+  await facetRow.hover();
+  await expect(facetRow.getByRole("button", { name: "new question" })).toBeVisible();
+  await expect(facetRow.getByRole("button", { name: "new facet" })).toHaveCount(0);
+
+  // --- Cleanup ---
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  // The facet was created moments ago -- the ArangoSearch view backing
+  // /dfiq/search is eventually consistent (same gotcha as elsewhere in
+  // this suite), so a single one-shot search can miss it here and
+  // silently skip its deletion rather than fail loudly. Retry until it
+  // shows up.
+  let facetMatches: { id: string }[] = [];
+  await expect(async () => {
+    const searchResponse = await page.request.post("/api/v2/dfiq/search", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: { query: { name: facetName }, count: 10, page: 0, sorting: [] }
+    });
+    ({ dfiq: facetMatches } = await searchResponse.json());
+    expect(facetMatches.length).toBeGreaterThan(0);
+  }).toPass({ timeout: 20_000 });
+  for (const match of facetMatches) {
+    await page.request.delete(`/api/v2/dfiq/${match.id}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  }
+  await page.request.delete(`/api/v2/dfiq/${scenarioId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+});

--- a/integration-tests/playwright/tests/dfiq-question-approaches.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-question-approaches.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * The Approaches tab (EditDFIQObject.vue) is the most intricate untested UI
+ * in the app: nested expansion panels, an in-memory YAML document rebuilt
+ * from typed fields (name/description/references/steps/coverage notes) and
+ * re-validated on a 500ms debounce, same as the rest of the DFIQ dialog.
+ * This creates a standalone Question, adds one approach with a reference
+ * and a step, saves, and confirms it round-tripped -- both in the
+ * read-only DFIQApproaches display on the details page (no reload, since
+ * ObjectDetails.vue's @success handler swaps the local object in place)
+ * and via a direct API GET of the persisted dfiq_yaml.
+ */
+test("add an approach with a reference and a step to a DFIQ question", async ({ page }) => {
+  const questionName = `integration-test-question-approach-${Date.now()}`;
+  const approachName = `integration-test-approach-${Date.now()}`;
+  const referenceText = `https://example.com/reference-${Date.now()}`;
+  const stepName = `integration-test-step-${Date.now()}`;
+  const stepValue = `SELECT * FROM step_${Date.now()}`;
+
+  await login(page);
+
+  // --- Create a standalone question (no parents needed) ---
+  await page.goto("/dfiq");
+  await page.getByRole("button", { name: "New DFIQ object" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Question" }).first().click();
+
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("Creating DFIQ question")).toBeVisible();
+  await newDialog.getByLabel("Name").fill(questionName);
+  await expect(newDialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await newDialog.getByRole("button", { name: "Save" }).click();
+  await expect(page).toHaveURL(/\/dfiq\/[\w-]+$/);
+  const questionId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Edit: add an approach with a reference and a step ---
+  await page.getByRole("button", { name: "Edit" }).click();
+  const editDialog = page.getByRole("dialog");
+  await expect(editDialog.getByText("Editing DFIQ question")).toBeVisible();
+
+  await editDialog.getByRole("tab", { name: "Approaches" }).click();
+  // v-window doesn't unmount the "user-form" tab once it's been visited
+  // (the dialog opens on it by default), so its own "Description" field
+  // stays in the DOM and collides with the approach's -- scope to the
+  // active window item, same pattern as the neighbor-table gotcha in the
+  // README.
+  const approachesTab = editDialog.locator(".v-window-item--active");
+  await approachesTab.getByRole("button", { name: "Add approach" }).click();
+
+  // Several of these fields (Reference, Step name) also carry a "clear"
+  // append-icon whose own aria-label ("<field> appended action") fuzzy-
+  // matches getByLabel too -- use getByRole("textbox", ...) instead, which
+  // only matches the actual input/textarea.
+  await approachesTab.getByRole("textbox", { name: "Approach name" }).fill(approachName);
+  await approachesTab.getByRole("textbox", { name: "Description" }).fill("Approach description");
+
+  await approachesTab.getByRole("button", { name: "add reference" }).click();
+  await approachesTab.getByRole("textbox", { name: "Reference" }).fill(referenceText);
+
+  await approachesTab.getByRole("button", { name: "Add step" }).click();
+  await approachesTab.getByRole("textbox", { name: "Step name" }).fill(stepName);
+  await approachesTab.getByLabel("Type").fill("manual");
+  await approachesTab.getByLabel("Stage").fill("collection");
+  await approachesTab.getByRole("textbox", { name: "Value" }).fill(stepValue);
+
+  await expect(editDialog.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  const patchResponse = page.waitForResponse(
+    res => res.url().includes(`/dfiq/${questionId}`) && res.request().method() === "PATCH"
+  );
+  await editDialog.getByRole("button", { name: "Save" }).click();
+  await patchResponse;
+  await expect(editDialog).toBeHidden();
+
+  // --- Confirm it rendered in the read-only Approaches panel, no reload ---
+  // The question's own DFIQ tree tab is mounted (eagerly, same as other
+  // DFIQ tree views) even though we never click into it, and it renders
+  // this same step name in its own (v-show-hidden, `<ul>`-based) approach
+  // node -- scope to the `<ol>` YetiDFIQApproachTemplate.vue actually uses,
+  // to avoid matching that hidden duplicate.
+  await page.getByRole("button", { name: approachName }).click();
+  await expect(page.locator("ol li").filter({ hasText: stepName })).toBeVisible();
+  await expect(page.getByText(referenceText)).toBeVisible();
+
+  // --- Confirm it persisted server-side too ---
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const response = await page.request.get(`/api/v2/dfiq/${questionId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  const persisted = await response.json();
+  expect(persisted.approaches).toHaveLength(1);
+  expect(persisted.approaches[0].name).toBe(approachName);
+  expect(persisted.approaches[0].references).toContain(referenceText);
+  expect(persisted.approaches[0].steps).toHaveLength(1);
+  expect(persisted.approaches[0].steps[0].name).toBe(stepName);
+  expect(persisted.approaches[0].steps[0].value).toBe(stepValue);
+
+  // --- Cleanup ---
+  await page.request.delete(`/api/v2/dfiq/${questionId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+});

--- a/integration-tests/playwright/tests/dfiq-scenario-inline-question.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-scenario-inline-question.spec.ts
@@ -55,11 +55,20 @@ test("create a scenario, then add a question inline from its DFIQ tree", async (
     form: { username: TEST_USERNAME, password: TEST_PASSWORD }
   });
   const { access_token: accessToken } = await tokenResponse.json();
-  const searchResponse = await page.request.post("/api/v2/dfiq/search", {
-    headers: { Authorization: `Bearer ${accessToken}` },
-    data: { query: { name: questionName }, count: 10, page: 0, sorting: [] }
-  });
-  const { dfiq: questionMatches } = await searchResponse.json();
+  // The question was created moments ago -- the ArangoSearch view backing
+  // /dfiq/search is eventually consistent (same gotcha as elsewhere in
+  // this suite), so a single one-shot search can miss it here and
+  // silently skip its deletion rather than fail loudly. Retry until it
+  // shows up.
+  let questionMatches: { id: string }[] = [];
+  await expect(async () => {
+    const searchResponse = await page.request.post("/api/v2/dfiq/search", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: { query: { name: questionName }, count: 10, page: 0, sorting: [] }
+    });
+    ({ dfiq: questionMatches } = await searchResponse.json());
+    expect(questionMatches.length).toBeGreaterThan(0);
+  }).toPass({ timeout: 20_000 });
   for (const match of questionMatches) {
     await page.request.delete(`/api/v2/dfiq/${match.id}`, { headers: { Authorization: `Bearer ${accessToken}` } });
   }

--- a/integration-tests/playwright/tests/dfiq-scenario.spec.ts
+++ b/integration-tests/playwright/tests/dfiq-scenario.spec.ts
@@ -37,7 +37,16 @@ test("create a DFIQ scenario", async ({ page }) => {
   await editDialog.getByRole("button", { name: "Delete object" }).click();
   const confirmDialog = page.getByRole("dialog").last();
   await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  // Wait for the actual DELETE to land before checking below -- a bare
+  // .click() only waits for the click event to dispatch, not for the
+  // resulting request/response, so the immediate follow-up GET can race
+  // ahead of it under load (see observable-lifecycle.spec.ts for the same
+  // fix and more detail).
+  const deleteResponse = page.waitForResponse(
+    res => res.url().includes(`/dfiq/${scenarioId}`) && res.request().method() === "DELETE"
+  );
   await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+  await deleteResponse;
 
   const tokenResponse = await page.request.post("/api/v2/auth/token", {
     form: { username: TEST_USERNAME, password: TEST_PASSWORD }

--- a/integration-tests/playwright/tests/entity-edit.spec.ts
+++ b/integration-tests/playwright/tests/entity-edit.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * None of the other specs ever edit an existing object -- they all do
+ * create -> search/tag -> delete. This exercises the generic Edit dialog
+ * (EditObject.vue + ObjectFields.vue, shared by every object type) via the
+ * entity family: create a Malware entity with no description, edit it to
+ * add one, and confirm it persisted on the details page and via a direct
+ * API GET.
+ */
+test("edit an existing entity's description", async ({ page }) => {
+  const name = `integration-test-malware-edit-${Date.now()}`;
+  const description = `Updated description ${Date.now()}`;
+
+  await login(page);
+
+  // --- Create (no description) ---
+  await page.goto("/entities");
+  await page.getByRole("button", { name: "New Entity" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Malware" }).first().click();
+
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("New Malware")).toBeVisible();
+  await newDialog.getByLabel("Name").fill(name);
+  await newDialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(page).toHaveURL(/\/entities\/[\w-]+$/);
+  const entityId = new URL(page.url()).pathname.split("/").pop();
+  await expect(page.locator(".yeti-description")).toContainText("No description provided");
+
+  // --- Edit ---
+  await page.getByRole("button", { name: "Edit" }).click();
+  const editDialog = page.getByRole("dialog");
+  await expect(editDialog.getByText("Editing Malware")).toBeVisible();
+  await editDialog.getByLabel("Description").fill(description);
+
+  const patchResponse = page.waitForResponse(
+    res => res.url().includes(`/entities/${entityId}`) && res.request().method() === "PATCH"
+  );
+  await editDialog.getByRole("button", { name: "Save" }).click();
+  await patchResponse;
+  await expect(editDialog).toBeHidden();
+
+  // --- Confirm it persisted, without a reload ---
+  await expect(page.locator(".yeti-description")).toContainText(description);
+
+  // --- Confirm it persisted server-side too ---
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+  const response = await page.request.get(`/api/v2/entities/${entityId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  expect((await response.json()).description).toBe(description);
+
+  // --- Cleanup ---
+  await page.request.delete(`/api/v2/entities/${entityId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+});

--- a/integration-tests/playwright/tests/entity-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/entity-lifecycle.spec.ts
@@ -78,7 +78,16 @@ test("create, search, tag, and delete an entity", async ({ page }) => {
 
   const confirmDialog = page.getByRole("dialog").last();
   await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  // Wait for the actual DELETE to land before checking below -- a bare
+  // .click() only waits for the click event to dispatch, not for the
+  // resulting request/response, so the immediate follow-up GET can race
+  // ahead of it under load (see observable-lifecycle.spec.ts for the same
+  // fix and more detail).
+  const deleteResponse = page.waitForResponse(
+    res => res.url().includes(`/entities/${entityId}`) && res.request().method() === "DELETE"
+  );
   await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+  await deleteResponse;
 
   // --- Confirm gone ---
   // Direct API GET, not the search view -- deleting a tagged object pushes

--- a/integration-tests/playwright/tests/indicator-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/indicator-lifecycle.spec.ts
@@ -93,7 +93,16 @@ test("create, search, tag, and delete an indicator", async ({ page }) => {
 
   const confirmDialog = page.getByRole("dialog").last();
   await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  // Wait for the actual DELETE to land before checking below -- a bare
+  // .click() only waits for the click event to dispatch, not for the
+  // resulting request/response, so the immediate follow-up GET can race
+  // ahead of it under load (see observable-lifecycle.spec.ts for the same
+  // fix and more detail).
+  const deleteResponse = page.waitForResponse(
+    res => res.url().includes(`/indicators/${indicatorId}`) && res.request().method() === "DELETE"
+  );
   await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+  await deleteResponse;
 
   // --- Confirm gone ---
   // Direct API GET, not the search view -- deleting a tagged object pushes

--- a/integration-tests/playwright/tests/observable-lifecycle.spec.ts
+++ b/integration-tests/playwright/tests/observable-lifecycle.spec.ts
@@ -62,7 +62,16 @@ test("create, search, tag, and delete an observable", async ({ page }) => {
 
   const confirmDialog = page.getByRole("dialog").last();
   await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  // Wait for the actual DELETE to land before checking below -- a bare
+  // .click() only waits for the click event to dispatch, not for the
+  // resulting request/response, so the immediate follow-up GET can race
+  // ahead of it under load: fine on a quiet run, but flips consistently
+  // once enough other specs have run before it in the same worker.
+  const deleteResponse = page.waitForResponse(
+    res => res.url().includes(`/observables/${observableId}`) && res.request().method() === "DELETE"
+  );
   await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+  await deleteResponse;
 
   // --- Confirm gone ---
   // Query the API directly rather than the search view: tagging appears to


### PR DESCRIPTION
## Summary
- Two new integration specs closing the biggest coverage gaps identified for this release: `entity-edit.spec.ts` (editing an existing object -- every lifecycle spec previously only did create/search/delete, never edit, across *any* object type) and `dfiq-facet.spec.ts` + `dfiq-question-approaches.spec.ts` (DFIQ's Facet type and the Approaches tab, the most intricate untested UI in the app -- and the same area where two real production bugs were found and fixed earlier this cycle, missing-import + null-`dfiq_id` filter crash).
- While building these, found and fixed two real races in the *existing* suite (not just the new specs):
  - Every UI-driven delete (`dfiq-scenario`, `entity/indicator/observable-lifecycle`) clicked "Delete" and immediately checked for a 404, with nothing waiting for the browser's own DELETE request to land first. Reliable in isolation, but failed consistently once run after enough other specs pushed request latency up (reproduced: 4/4 failures running the full suite, 0/2 full-suite reruns after the fix). Now waits for the DELETE response before checking, matching the tag-step pattern already used elsewhere.
  - `dfiq-scenario-inline-question`'s cleanup (and the new `dfiq-facet` spec, which copied the same pattern) searched for the object it had just created in order to delete it -- hitting the same ArangoSearch eventual-consistency window already documented in the README for other cases. A miss silently skipped deletion instead of failing loudly (confirmed: found real orphaned DFIQ objects left behind from otherwise-passing runs). Now retries the search until it resolves.
- README updated with both new gotchas.

## Test plan
- [x] All 13 specs (10 existing + 3 new) run individually and together, twice in a row, against a live dev stack -- all green
- [x] `npx tsc --noEmit` on the playwright package -- clean
- [x] Confirmed the delete-race was real (not flaky) by reproducing it 100% of the time pre-fix across two separate full-suite runs, then 0% post-fix across two more
- [x] Confirmed the cleanup race was real by finding actual orphaned DFIQ objects left over from passing runs, then confirming zero orphans after the retry fix
- [x] No leftover test data
