### PR TITLE
Pin prod bloomcheck/yeti-agents to :dev, decoupled from YETI_IMAGE_TAG

### DIFF
--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -85,13 +85,13 @@ services:
       retries: 10
 
   bloomcheck:
-    image: yetiplatform/bloomcheck:${YETI_IMAGE_TAG:-latest}
+    image: yetiplatform/bloomcheck:dev
     entrypoint: ['/app/bloomcheck', '-serve', '/bloomfilters']
     volumes:
       - ${YETI_BLOOM_FILTERS_DIR}:/bloomfilters:ro
 
   agents:
-    image: yetiplatform/yeti-agents:${YETI_IMAGE_TAG:-latest}
+    image: yetiplatform/yeti-agents:dev
     env_file:
       - ${YETI_DOCKER_ENVFILE}
     environment:

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -84,6 +84,10 @@ services:
       start_period: 30s
       retries: 10
 
+  # bloomcheck/agents only ever publish a :dev tag today (no :latest, no
+  # numbered releases) -- pinned here independent of YETI_IMAGE_TAG so
+  # bumping that for a yeti/yeti-frontend release doesn't break these pulls.
+  # Move to a numbered tag or :latest once these images stabilize.
   bloomcheck:
     image: yetiplatform/bloomcheck:dev
     entrypoint: ['/app/bloomcheck', '-serve', '/bloomfilters']


### PR DESCRIPTION
## Summary
- `prod/docker-compose.yaml` tied `bloomcheck` and `agents` to the same `${YETI_IMAGE_TAG:-latest}` variable used for versioned `yeti`/`yeti-frontend` releases -- but both images only ever publish a `dev` tag on Docker Hub (confirmed via the Docker Hub API: no `latest`, no numbered tags exist for either). Bumping `YETI_IMAGE_TAG` for a numbered release (e.g. `2.6.0`, about to be cut) would silently break these two containers' image pulls.
- Hardcodes both to `:dev`, matching how `dev/docker-compose.yaml` already pins them (they're meant to always track bleeding-edge, independent of the api/frontend release cycle).

## Test plan
- [x] Confirmed via Docker Hub API that `yetiplatform/bloomcheck` and `yetiplatform/yeti-agents` have exactly one tag each (`dev`)
- [x] Diff is two one-line image tag changes, no other behavior affected