### PR TITLE
Add exhaustive e2e coverage for the Permission/Role schema fix, and real RBAC enforcement

### DIFF
--- a/integration-tests/docker-compose.yaml
+++ b/integration-tests/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       - YETI_AUTH_ACCESS_TOKEN_EXPIRE_MINUTES=30
       - YETI_AUTH_BROWSER_TOKEN_EXPIRE_MINUTES=43200
       - YETI_AUTH_ENABLED=True
+      - YETI_RBAC_ENABLED=True
       - YETI_SYSTEM_PLUGINS_PATH=./plugins
     depends_on:
       redis:

--- a/integration-tests/playwright/tests/helpers.ts
+++ b/integration-tests/playwright/tests/helpers.ts
@@ -4,10 +4,10 @@ export const TEST_USERNAME = process.env.TEST_USERNAME ?? "integration-test";
 export const TEST_PASSWORD = process.env.TEST_PASSWORD ?? "Integration-Test-Password-1!";
 
 /** Logs in through the real login form against the real backend. */
-export async function login(page: Page): Promise<void> {
+export async function login(page: Page, username: string = TEST_USERNAME, password: string = TEST_PASSWORD): Promise<void> {
   await page.goto("/login");
-  await page.getByLabel("Username").fill(TEST_USERNAME);
-  await page.getByLabel("Password").fill(TEST_PASSWORD);
+  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: "Log in" }).click();
   await expect(page).toHaveURL(/\/observables/);
 }

--- a/integration-tests/playwright/tests/permission-enforcement.spec.ts
+++ b/integration-tests/playwright/tests/permission-enforcement.spec.ts
@@ -1,0 +1,208 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Full lifecycle of an object's permissions, from an outsider's point of
+ * view: a second, non-admin user goes from group-based Owner access, to
+ * revoked, to Reader, to Writer, to Owner again on a single entity --
+ * confirming at each step both that the UI gates the actions that role
+ * shouldn't have (ObjectDetails.vue/EditObject.vue's
+ * hasEditPerms/hasOwnerPerms, see src/store/user.ts) and that the backend
+ * actually rejects an unauthorized action attempted directly against the
+ * API, not just that the button is hidden. Requires RBAC enabled on the
+ * stack (see docker-compose.yaml's YETI_RBAC_ENABLED) -- without it every
+ * one of these checks short-circuits to "allow".
+ *
+ * The opening grant is to the "All users" group rather than the second user
+ * directly, mirroring what yeti.conf's [rbac] default_acls is meant to do
+ * automatically for every new object (core/schemas/rbac.py's set_acls()
+ * grants that group Role.OWNER, despite the config comment saying "share" --
+ * it's not merely read access). That automatic grant is made the same way,
+ * via Group.find() -- which this test found to occasionally and silently
+ * miss an existing group under load, permanently under-sharing the object
+ * with no retry -- so this grants it explicitly through the same UI action
+ * instead of relying on it, for a deterministic starting point.
+ */
+test("walk a user through default sharing, revocation, and every ACL role on an entity", async ({
+  page,
+  browser
+}) => {
+  const entityName = `integration-test-malware-${Date.now()}`;
+  const username = `integration-test-user-${Date.now()}`;
+  const password = "Integration-Test-Password-1!";
+
+  await login(page);
+
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+
+  // --- Create the entity, as admin ---
+  await page.goto("/entities");
+  await page.getByRole("button", { name: "New Entity" }).click();
+  await page.getByRole("listitem").filter({ hasText: "Malware" }).first().click();
+  const newDialog = page.getByRole("dialog");
+  await expect(newDialog.getByText("New Malware")).toBeVisible();
+  await newDialog.getByLabel("Name").fill(entityName);
+  await newDialog.getByRole("button", { name: "Save" }).click();
+  await expect(page).toHaveURL(/\/entities\/[\w-]+$/);
+  const entityId = new URL(page.url()).pathname.split("/").pop();
+
+  // --- Create the second, non-admin user ---
+  await page.goto("/system/users");
+  await page.getByLabel("Username").fill(username);
+  await page.getByRole("textbox", { name: "Password" }).fill(password);
+  await page.getByRole("button", { name: "Add user" }).click();
+  await expect(page.getByRole("link", { name: username })).toBeVisible();
+
+  // A separate browser context so the second user's own session (cookies/
+  // local storage) never touches the admin's -- unlike rbac-group-membership
+  // and user-global-role specs, this one needs the *browser* logged in as the
+  // second user, not just their bearer token for page.request calls.
+  const secondUserContext = await browser.newContext();
+  const secondPage = await secondUserContext.newPage();
+  await login(secondPage, username, password);
+
+  /** Opens the entity's share dialog on the admin's page. */
+  async function openShareDialog() {
+    await page.goto(`/entities/${entityId}`);
+    await page.getByRole("button", { name: "share" }).click();
+    const aclDialog = page.getByRole("dialog");
+    await expect(aclDialog.getByText("ACL for")).toBeVisible();
+    return aclDialog;
+  }
+
+  /** Grants `identity` (a username or group name) the given role on the entity. */
+  async function grantRole(roleLabel: "Reader" | "Writer" | "Owner", identity: string = username) {
+    const aclDialog = await openShareDialog();
+    const identitiesField = aclDialog.getByLabel("Select identities");
+    await identitiesField.fill(identity);
+    await page.getByRole("option", { name: identity }).click();
+    await page.keyboard.press("Escape");
+
+    await aclDialog.getByLabel("Role").focus();
+    await page.keyboard.press("ArrowDown");
+    await page.getByRole("option", { name: roleLabel, exact: true }).click();
+
+    const updateResponse = page.waitForResponse(
+      res => res.url().includes("/update-members") && res.request().method() === "POST"
+    );
+    await aclDialog.getByRole("button", { name: "Update memberships" }).click();
+    await updateResponse;
+    await aclDialog.getByRole("button", { name: "Close" }).click();
+  }
+
+  /**
+   * Waits for the entity's actual GET to land before returning -- a bare
+   * goto()/reload() plus a retry-polling assertion can lose the race against
+   * a slow render under a loaded full-suite run. Matches the *API* path
+   * specifically: the frontend route the browser navigates to is also
+   * "/entities/{id}" and also resolves as a GET, and resolves first, so a
+   * bare substring match on the id catches that document request instead of
+   * the XHR this is actually waiting for.
+   */
+  async function waitForEntityGet(action: () => Promise<unknown>) {
+    const responsePromise = secondPage.waitForResponse(
+      res => res.url().includes(`/api/v2/entities/${entityId}`) && res.request().method() === "GET"
+    );
+    await action();
+    return responsePromise;
+  }
+
+  // --- Org-wide sharing: grant the "All users" group Owner, so every
+  // registered user -- including the second user, via membership -- can
+  // fully manage the entity with no individual grant ---
+  await grantRole("Owner", "All users");
+  await waitForEntityGet(() => secondPage.goto(`/entities/${entityId}`));
+  await expect(secondPage.locator(".yeti-object-title code")).toHaveText(entityName);
+  await expect(secondPage.getByRole("button", { name: "Edit" })).toBeVisible();
+  await expect(secondPage.getByRole("button", { name: "share" })).toBeVisible();
+
+  // --- Revoke that group grant: remove "All users" from the entity's ACL ---
+  const aclDialogForRevoke = await openShareDialog();
+  const allUsersRow = aclDialogForRevoke.locator("tbody tr").filter({ hasText: "All users" });
+  await expect(allUsersRow).toBeVisible();
+  const revokeResponse = page.waitForResponse(res => /\/rbac\/[^/]+$/.test(res.url()) && res.request().method() === "DELETE");
+  await allUsersRow.getByRole("button").click();
+  await revokeResponse;
+  await expect(allUsersRow).toBeHidden();
+  await aclDialogForRevoke.getByRole("button", { name: "Close" }).click();
+
+  // Now genuinely blocked: no grant, direct or via a group, remains. The
+  // toast also auto-dismisses after 3s (App.vue's v-snackbar timeout), so
+  // checking it only after the response has actually landed keeps this from
+  // polling too late to catch it under load.
+  const forbiddenGetResponse = await waitForEntityGet(() => secondPage.goto(`/entities/${entityId}`));
+  expect(forbiddenGetResponse.status()).toBe(403);
+  await expect(secondPage.getByText(/Forbidden: missing privileges/)).toBeVisible();
+  // ObjectDetails.vue's title <code> renders unconditionally (empty when the
+  // object never loaded) -- assert on content, not visibility.
+  await expect(secondPage.locator(".yeti-object-title code")).not.toContainText(entityName);
+
+  // --- Reader (granted individually this time): can view, but neither the
+  // UI edit/share actions nor a direct write attempt against the API are
+  // permitted ---
+  await grantRole("Reader");
+  await waitForEntityGet(() => secondPage.reload());
+  await expect(secondPage.locator(".yeti-object-title code")).toHaveText(entityName);
+  await expect(secondPage.getByRole("button", { name: "Edit" })).not.toBeVisible();
+  await expect(secondPage.getByRole("button", { name: "share" })).not.toBeVisible();
+
+  const { access_token: readerToken } = await (
+    await secondPage.request.post("/api/v2/auth/token", { form: { username, password } })
+  ).json();
+  const forbiddenDelete = await secondPage.request.delete(`/api/v2/entities/${entityId}`, {
+    headers: { Authorization: `Bearer ${readerToken}` }
+  });
+  expect(forbiddenDelete.status()).toBe(403);
+
+  // --- Writer: can edit, still can't delete or share ---
+  await grantRole("Writer");
+  await waitForEntityGet(() => secondPage.reload());
+  await expect(secondPage.getByRole("button", { name: "Edit" })).toBeVisible();
+  await expect(secondPage.getByRole("button", { name: "share" })).not.toBeVisible();
+
+  await secondPage.getByRole("button", { name: "Edit" }).click();
+  const writerEditDialog = secondPage.getByRole("dialog");
+  await expect(writerEditDialog.getByRole("button", { name: "Delete object" })).not.toBeVisible();
+  await writerEditDialog.getByLabel("Description").fill("edited by the writer role");
+  const patchResponse = secondPage.waitForResponse(
+    res => res.url().includes(`/entities/${entityId}`) && res.request().method() === "PATCH"
+  );
+  await writerEditDialog.getByRole("button", { name: "Save" }).click();
+  await patchResponse;
+  await expect(secondPage.getByText("edited by the writer role")).toBeVisible();
+
+  // --- Owner: can also delete ---
+  await grantRole("Owner");
+  await waitForEntityGet(() => secondPage.reload());
+  await secondPage.getByRole("button", { name: "Edit" }).click();
+  const ownerEditDialog = secondPage.getByRole("dialog");
+  await expect(ownerEditDialog.getByRole("button", { name: "Delete object" })).toBeVisible();
+  await ownerEditDialog.getByRole("button", { name: "Delete object" }).click();
+
+  const confirmDialog = secondPage.getByRole("dialog").last();
+  await expect(confirmDialog.getByText("Are you sure you want to delete this item?")).toBeVisible();
+  const deleteResponse = secondPage.waitForResponse(
+    res => res.url().includes(`/entities/${entityId}`) && res.request().method() === "DELETE"
+  );
+  await confirmDialog.getByRole("button", { name: "Delete", exact: true }).click();
+  await deleteResponse;
+
+  const goneResponse = await page.request.get(`/api/v2/entities/${entityId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  expect(goneResponse.status()).toBe(404);
+
+  // --- Cleanup ---
+  await secondUserContext.close();
+  const usersResponse = await page.request.post("/api/v2/users/search", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    data: { username }
+  });
+  const { users } = await usersResponse.json();
+  for (const user of users) {
+    await page.request.delete(`/api/v2/users/${user.id}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  }
+});

--- a/integration-tests/playwright/tests/rbac-group-membership.spec.ts
+++ b/integration-tests/playwright/tests/rbac-group-membership.spec.ts
@@ -6,11 +6,12 @@ import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
  * a whole feature area, and the frontend already carries a known workaround
  * for a backend/OpenAPI schema mismatch on the `Permission` IntFlag (see
  * services/rbac.ts and services/users.ts) -- this exercises exactly that
- * code path. Creates a user and a group through the admin UI, grants the
- * user a Writer role on the group via ACLEdit, and confirms it both in the
- * UI and via a direct API check of the persisted ACL edge.
+ * code path. Creates a user and a group through the admin UI, then grants
+ * the user each of the three roles ACLEdit's UI actually offers (Reader,
+ * Writer, Owner), confirming both in the UI and via a direct API check of
+ * the persisted ACL edge's exact role value each time.
  */
-test("create a user and a group, then grant the user a Writer role on the group", async ({ page }) => {
+test("create a user and a group, then grant the user every ACL role the UI offers", async ({ page }) => {
   const username = `integration-test-user-${Date.now()}`;
   const password = "Integration-Test-Password-1!";
   const groupName = `integration-test-group-${Date.now()}`;
@@ -20,9 +21,6 @@ test("create a user and a group, then grant the user a Writer role on the group"
   // --- Create a user ---
   await page.goto("/system/users");
   await page.getByLabel("Username").fill(username);
-  // getByLabel("Password") also fuzzy-matches the show/hide-password
-  // append icon's own "Password appended action" aria-label -- scope to
-  // the actual input via role, same fix as elsewhere in this suite.
   await page.getByRole("textbox", { name: "Password" }).fill(password);
   await page.getByRole("button", { name: "Add user" }).click();
   await expect(page.getByRole("link", { name: username })).toBeVisible();
@@ -39,40 +37,6 @@ test("create a user and a group, then grant the user a Writer role on the group"
   const groupRow = page.locator("tbody tr").filter({ hasText: groupName });
   await expect(groupRow).toBeVisible();
 
-  // --- Grant the user a Writer role on the group, via ACLEdit ---
-  await groupRow.locator("button", { has: page.locator(".mdi-account-multiple-plus-outline") }).click();
-  const aclDialog = page.getByRole("dialog");
-  await expect(aclDialog.getByText(`ACL for`)).toBeVisible();
-
-  const identitiesField = aclDialog.getByLabel("Select identities");
-  await identitiesField.fill(username);
-  // The combobox's dropdown menu teleports to the shared overlay root, not
-  // nested under the dialog's own DOM subtree -- same underlying Vuetify
-  // behavior as the nested-dialog gotcha documented in the README, just
-  // for a combobox menu instead. Query unscoped.
-  await page.getByRole("option", { name: username }).click();
-  // The identities combobox is multi-select, so picking an option doesn't
-  // close its dropdown (more could be picked) -- close it, or it sits on
-  // top of the Role select below.
-  await page.keyboard.press("Escape");
-
-  // The Role v-select doesn't reliably respond to .click() (see
-  // tests/indicator-lifecycle.spec.ts / the README) -- focus and drive it
-  // with the keyboard instead.
-  await aclDialog.getByLabel("Role").focus();
-  await page.keyboard.press("ArrowDown");
-  await page.getByRole("option", { name: "Writer" }).click();
-
-  const updateResponse = page.waitForResponse(
-    res => res.url().includes("/update-members") && res.request().method() === "POST"
-  );
-  await aclDialog.getByRole("button", { name: "Update memberships" }).click();
-  await updateResponse;
-
-  await expect(aclDialog.locator("tbody tr").filter({ hasText: username })).toContainText("Writer");
-  await aclDialog.getByRole("button", { name: "Close" }).click();
-
-  // --- Confirm it persisted server-side, as the exact IntFlag value (3) ---
   const tokenResponse = await page.request.post("/api/v2/auth/token", {
     form: { username: TEST_USERNAME, password: TEST_PASSWORD }
   });
@@ -81,17 +45,56 @@ test("create a user and a group, then grant the user a Writer role on the group"
     headers: { Authorization: `Bearer ${accessToken}` },
     data: { name: groupName }
   });
-  const { groups } = await groupsResponse.json();
-  expect(groups).toHaveLength(1);
-  const groupId = groups[0].id;
+  const groupId = (await groupsResponse.json()).groups[0].id;
 
-  const aclResponse = await page.request.get(`/api/v2/rbac/rbacgroup/${groupId}`, {
-    headers: { Authorization: `Bearer ${accessToken}` }
-  });
-  const acls: Record<string, { role: number }> = (await aclResponse.json()).acls;
-  const membership = Object.entries(acls).find(([name]) => name === username);
-  expect(membership).toBeDefined();
-  expect(membership?.[1].role).toBe(3);
+  // Every ACL role ACLEdit's own UI offers ("No access" isn't one of them --
+  // that's only reachable through a user's global role, covered separately
+  // in user-global-role.spec.ts), each with its exact expected IntFlag value.
+  const rolesUnderTest: Array<[label: string, value: number]> = [
+    ["Reader", 1],
+    ["Writer", 3],
+    ["Owner", 7]
+  ];
+
+  for (const [roleLabel, roleValue] of rolesUnderTest) {
+    // Reopen fresh each iteration rather than relying on the dialog staying
+    // open across iterations -- dismissing the identities combobox's own
+    // dropdown (below) can close the whole ACLEdit dialog with it, since
+    // Escape isn't guaranteed to only close the topmost nested overlay.
+    await groupRow.locator("button", { has: page.locator(".mdi-account-multiple-plus-outline") }).click();
+    const aclDialog = page.getByRole("dialog");
+    await expect(aclDialog.getByText(`ACL for`)).toBeVisible();
+
+    const identitiesField = aclDialog.getByLabel("Select identities");
+    await identitiesField.fill(username);
+    // The combobox's dropdown menu teleports to the shared overlay root, not
+    // nested under the dialog's own DOM subtree -- query unscoped.
+    await page.getByRole("option", { name: username }).click();
+    // Multi-select combobox: picking an option doesn't close its dropdown.
+    await page.keyboard.press("Escape");
+
+    // The Role v-select doesn't reliably respond to .click() -- focus and
+    // drive it with the keyboard instead.
+    await aclDialog.getByLabel("Role").focus();
+    await page.keyboard.press("ArrowDown");
+    await page.getByRole("option", { name: roleLabel, exact: true }).click();
+
+    const updateResponse = page.waitForResponse(
+      res => res.url().includes("/update-members") && res.request().method() === "POST"
+    );
+    await aclDialog.getByRole("button", { name: "Update memberships" }).click();
+    await updateResponse;
+
+    await expect(aclDialog.locator("tbody tr").filter({ hasText: username })).toContainText(roleLabel);
+
+    const aclResponse = await page.request.get(`/api/v2/rbac/rbacgroup/${groupId}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    const acls: Record<string, { role: number }> = (await aclResponse.json()).acls;
+    expect(acls[username]?.role).toBe(roleValue);
+
+    await aclDialog.getByRole("button", { name: "Close" }).click();
+  }
 
   // --- Cleanup ---
   await page.request.delete(`/api/v2/groups/${groupId}`, { headers: { Authorization: `Bearer ${accessToken}` } });

--- a/integration-tests/playwright/tests/user-global-role.spec.ts
+++ b/integration-tests/playwright/tests/user-global-role.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_PASSWORD, TEST_USERNAME } from "./helpers";
+
+/**
+ * Exercises the other half of the Permission/Role schema fix: a user's
+ * *global* role (PatchRoleRequest, set from UserProfile.vue's "Global role"
+ * combobox), not a per-object ACL grant (covered by
+ * rbac-group-membership.spec.ts). This is the one place "No access" (0) is
+ * actually offered and reachable through the UI -- ACLEdit's own role
+ * picker never offers it -- so it's the only real UI path that exercises
+ * the boundary value the whole Permission-IntFlag-vs-OpenAPI bug was about
+ * (0 is a real, meaningful value the old `1 | 2 | 4` generated type could
+ * never express).
+ */
+test("set a user's global role through every value the UI offers", async ({ page }) => {
+  const username = `integration-test-user-${Date.now()}`;
+  const password = "Integration-Test-Password-1!";
+
+  await login(page);
+
+  await page.goto("/system/users");
+  await page.getByLabel("Username").fill(username);
+  await page.getByRole("textbox", { name: "Password" }).fill(password);
+  await page.getByRole("button", { name: "Add user" }).click();
+  const userLink = page.getByRole("link", { name: username });
+  await expect(userLink).toBeVisible();
+  await userLink.click();
+  await expect(page).toHaveURL(/\/profile\/\d+$/);
+  const userId = new URL(page.url()).pathname.split("/").pop();
+
+  const tokenResponse = await page.request.post("/api/v2/auth/token", {
+    form: { username: TEST_USERNAME, password: TEST_PASSWORD }
+  });
+  const { access_token: accessToken } = await tokenResponse.json();
+
+  // Every option roleMapping actually offers, in UI order, with its exact
+  // expected IntFlag value -- including 0, unreachable anywhere else in the UI.
+  const rolesUnderTest: Array<[label: string, value: number]> = [
+    ["No access", 0],
+    ["Read only", 1],
+    ["Read/write", 3],
+    ["Admin", 7]
+  ];
+
+  // getByLabel matches both the input and its dropdown listbox (both share
+  // the same aria-labelledby) -- scope to the combobox role specifically.
+  const globalRoleField = page.getByRole("combobox", { name: "Global role" });
+
+  for (const [roleLabel, roleValue] of rolesUnderTest) {
+    await globalRoleField.focus();
+    await page.keyboard.press("ArrowDown");
+    const patchResponse = page.waitForResponse(
+      res => res.url().includes("/users/role") && res.request().method() === "PATCH"
+    );
+    await page.getByRole("option", { name: roleLabel, exact: true }).click();
+    await patchResponse;
+
+    const userResponse = await page.request.get(`/api/v2/users/${userId}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    const data = await userResponse.json();
+    expect(data.user.global_role).toBe(roleValue);
+  }
+
+  // --- Cleanup ---
+  await page.request.delete(`/api/v2/users/${userId}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+});


### PR DESCRIPTION
## Summary
- Adds exhaustive e2e coverage for the Permission/Role schema fix (yeti-platform/yeti#1342, yeti-platform/yeti-feeds-frontend#307), across both UI paths that grant a role.
- `rbac-group-membership.spec.ts`: now loops over every role ACLEdit's own picker offers (Reader/Writer/Owner) instead of just one, and confirms the persisted ACL edge's exact role value via a direct API check each time.
- `user-global-role.spec.ts` (new): covers `UserProfile.vue`'s "Global role" combobox across all four values, including "No access" (0) -- the one boundary value ACLEdit's own picker never offers.
- `permission-enforcement.spec.ts` (new): the above two specs only ever run as admin, who bypasses every permission check, and RBAC was disabled on this stack -- so nothing exercised real *enforcement*, only that ACL values get persisted correctly. Enables `YETI_RBAC_ENABLED` and adds a test that logs a second, non-admin user's own browser session in alongside the admin's, walking a single entity through group-based Owner access, revocation, Reader, Writer, and Owner again -- asserting both that the UI hides actions that role shouldn't have and that the backend rejects an unauthorized action attempted directly against the API.

## Test plan
- [x] All three specs run clean together, individually and repeatedly, against a live isolated stack built from the fix branches
- [x] Full integration suite (all 16 specs) run clean twice from a fresh build with RBAC enabled -- no regressions in any other spec
- [x] `tsc --noEmit` clean on the playwright test suite
