### PR TITLE
Add a persistent volume for ChromaDB's semantic-search index

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
         condition: service_healthy
     volumes:
       - /tmp/docker-yeti-exports:/opt/yeti/exports
+      - /tmp/docker-yeti-chromadb:/data/chromadb
       - ./yeti/:/app/
     stdin_open: true # docker run -i
     tty: true        # docker run -t

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
         condition: service_healthy
     volumes:
       - yeti-exports:/opt/yeti/exports
+      - yeti-chromadb-data:/data/chromadb
 
   tasks:
     image: yetiplatform/yeti:${YETI_IMAGE_TAG:-latest}
@@ -40,6 +41,7 @@ services:
         condition: service_started
     volumes:
       - yeti-exports:/opt/yeti/exports
+      - yeti-chromadb-data:/data/chromadb
 
   events-tasks:
     image: yetiplatform/yeti:${YETI_IMAGE_TAG:-latest}
@@ -114,4 +116,6 @@ volumes:
   yeti-exports:
     driver: local
   yeti-db:
+    driver: local
+  yeti-chromadb-data:
     driver: local


### PR DESCRIPTION
## Summary
Companion to yeti-platform/yeti#1345. Neither `dev/docker-compose.yaml` nor `prod/docker-compose.yaml` mounted anything at `/data/chromadb` (the path `core/chromadb_client.py`'s `PersistentClient` reads/writes), so the semantic-search index was silently wiped on every container recreate and rebuilt from scratch by the next scheduled indexer run.

- `prod/docker-compose.yaml`: new named volume `yeti-chromadb-data`, mounted into both `api` (reads via `/search/semantic`) and `tasks` (the celery worker that runs the scheduled `ChromaDBIndexer` analytics task).
- `dev/docker-compose.yaml`: single bind mount on the one `api` container, since dev runs everything (webserver + task worker, started manually via `docker exec`/tmux) in that one container.

## Test plan
- [ ] Not runtime-tested here (compose-only change, no application code) -- worth a sanity check that a `docker compose down && up` in dev preserves indexed embeddings across the restart once this lands.